### PR TITLE
Small bugfix in Bio::SeqIO::swiss

### DIFF
--- a/Bio/SeqIO/swiss.pm
+++ b/Bio/SeqIO/swiss.pm
@@ -511,7 +511,7 @@ sub write_seq {
         }
 
         # namespace dictates database, takes precedent over division. Sorry!
-        if (defined($ns)) {
+        if (defined($ns) && $ns ne '') {
             $div = ($ns eq 'Swiss-Prot') ? 'Reviewed'    :
                 ($ns eq 'TrEMBL')     ? 'Unreviewed' :
                     $ns;

--- a/t/SeqIO/swiss.t
+++ b/t/SeqIO/swiss.t
@@ -7,7 +7,7 @@ BEGIN {
     use lib '.';
     use Bio::Root::Test;
     
-    test_begin(-tests => 240);
+    test_begin(-tests => 245);
 	
     use_ok('Bio::SeqIO::swiss');
 }
@@ -395,3 +395,52 @@ while (my $seq = $seqio->next_seq) {
 		'Acetobacter;Acetobacteraceae;Rhodospirillales;Alphaproteobacteria;'.
 		'Proteobacteria;Bacteria');
 }
+
+# Test for roundtrippability swiss->fasta->swiss
+# 1. Swiss -> Fasta
+$seqio = Bio::SeqIO->new(
+    -verbose => $verbose,
+    -format  => 'swiss',
+    -file    => test_input_file('test.swiss'),
+);
+my $fasta_output = test_output_file();
+my $seqio_out = Bio::SeqIO->new(
+    -verbose => $verbose,
+    -format  => 'fasta',
+    -file    => ">$fasta_output",
+);
+
+my $seq_first = $seqio->next_seq();
+$seqio_out->write_seq( $seq_first );
+
+# 2. Fasta -> Swiss
+my $swiss_output = test_output_file();
+$seqio = Bio::SeqIO->new(
+    -verbose => $verbose,
+    -format  => 'fasta',
+    -file    => $fasta_output,
+);
+$seqio_out = Bio::SeqIO->new(
+    -verbose => $verbose,
+    -format  => 'swiss',
+    -file    => ">$swiss_output",
+);
+my $seq_second = $seqio->next_seq();
+is( $seq_second->id,  $seq_first->id,  'Converting to fasta seqids match');
+is( $seq_second->seq, $seq_first->seq, 'Converting to fasta sequences match');
+$seqio_out->write_seq( $seq_second );
+
+# 3. Check that we can open and read the resulting swiss-prot file
+
+$seqio = Bio::SeqIO->new(
+    -verbose => $verbose,
+    -format  => 'swiss',
+    -file    => $swiss_output,
+);
+my $seq_third;
+SKIP: {
+    skip "Can't parse generated swissprot file", 1
+        unless lives_ok( sub {$seq_third = $seqio->next_seq()}, 'Can parse generated swiss' );
+    is( $seq_third->id,  $seq_first->id,  'Roundtrip, seqids match');
+    is( $seq_third->seq, $seq_first->seq, 'Roundtrip, sequences match');
+};


### PR DESCRIPTION
Hello,

I found a bug in Bio::SeqIO::swiss where write_seq() generated an empty division tag in the ID field. The reason for this was that the namespace was used if it was defined, unfortunately, namespace is sometimes defined and empty.

I fixed the bug and added some tests that catches this.

/Johan
