### PR TITLE
documentation change "usage gff_file1" > "usage gff_or_fasta_file1"

### DIFF
--- a/scripts/Bio-SeqFeature-Store/bp_seqfeature_load.PLS
+++ b/scripts/Bio-SeqFeature-Store/bp_seqfeature_load.PLS
@@ -39,7 +39,7 @@ GetOptions(
        'S|subfeatures!' => \$INDEX_SUB,
        'noalias-target' => \$NOALIAS_TARGET,
        'summary'        => \$SUMMARY_STATS,
-       ) || die usage;
+       ) || die &usage;
 
 
 


### PR DESCRIPTION
I also re-formatted the usage notes, and broke the usage string into a subroutine so that it can be called when no options or files are passed or when --help|h is called.
