### PR TITLE
bugfix and new behaviour with negative coordinates

### DIFF
--- a/Bio/SeqUtils.pm
+++ b/Bio/SeqUtils.pm
@@ -1267,8 +1267,16 @@ sub _coord_adjust {
         my @coords=($_->start, $_->end);
         my $strand=$_->strand;
 	my $type=$_->location_type;
-        map s/(-?\d+)/if ($add+$1<1) {'<1'} elsif (defined $length and $add+$1>$length) {">$length"} else {$add+$1}/ge, @coords;
-
+        foreach (@coords){
+            $self->throw("can not handle negative feature positions (got: $_)") if $_<0;;
+            if ($add+$_<1) {
+                $_ = '<1';
+            } elsif (defined $length and $add+$_>$length) {
+                $_ = ">$length" ;
+            } else {
+                $_ = $add+$_ ;
+            }
+        }
         push @loc, $self->_location_objects_from_coordinate_list(
           [\@coords], $strand, $type
         );

--- a/t/SeqTools/SeqUtils.t
+++ b/t/SeqTools/SeqUtils.t
@@ -8,7 +8,7 @@ BEGIN {
 #    use List::MoreUtils qw(uniq);
     use Bio::Root::Test;
     
-    test_begin(-tests => 128);
+    test_begin(-tests => 130);
 	
 	use_ok('Bio::PrimarySeq');
 	use_ok('Bio::SeqUtils');
@@ -203,7 +203,7 @@ my $ft3 = Bio::SeqFeature::Generic->new( -start => 3,
 $seq2->add_SeqFeature($ft2);
 $seq2->add_SeqFeature($ft3);
 
-
+my $seq1_length = $seq1->length;
 ok (Bio::SeqUtils->cat($seq1, $seq2));
 is $seq1->seq, 'aaaattttcccctttt';
 is scalar $seq1->annotation->get_Annotations, 5;
@@ -214,6 +214,10 @@ lives_ok {
   @tags = map{$_->get_tag_values(q(note))}$seq1->get_SeqFeatures ;
 } 'cat - note tag transfered (no throw)';
 cmp_ok(scalar(@tags),'==',3, 'cat - note tag values transfered (correct count)') ;
+my ($ft3_precat) = grep ($_->primary_tag eq 'hotspot', $seq2->get_SeqFeatures);
+is ($ft3_precat->start, 3, "get correct start of feature before 'cat'");
+my ($ft3_cat) = grep ($_->primary_tag eq 'hotspot', $seq1->get_SeqFeatures);
+is ($ft3_cat->start, 3+$seq1_length, "get correct start of feature after 'cat'");
 
 
 my $protseq = Bio::PrimarySeq->new(-id => 2, -seq => 'MVTF'); # protein seq


### PR DESCRIPTION
As discussed on the bioperl mailing list, I have modified Bio::SeqUtils::_coord_adjust so that it will throw an exception if negative coordinates are seen. Had to slightly change the existing code to allow checking for negative coords.
Also fixed a bug which cause incorrect postion adjustments from Bio::SeqUtils::delete action if a feature started at the same position as the deletion and ended beyond the deletion's end.
Aded a few tests for these cases.
