### PR TITLE
Fixed Bug 3343 by correctly calculating the total gaps

### DIFF
--- a/Bio/SearchIO/blasttable.pm
+++ b/Bio/SearchIO/blasttable.pm
@@ -219,6 +219,16 @@ sub next_result{
 	      $gapsm=$qgaps+$sgaps;
 	  }
 
+       if (@fields == 12 || @fields == 13) {
+          # need to determine total gaps in the alignment for NCBI output
+          # since NCBI reports number of gapopens and NOT total gaps
+          my $qlen      = abs($qstart - $qend) + 1;
+          my $querygaps = $hsp_len - $qlen;
+          my $hlen      = abs($hstart - $hend) + 1;
+          my $hitgaps   = $hsp_len - $hlen;
+          $gapsm = $querygaps + $hitgaps;
+       }
+
        # Remember Jim's code is 0 based
        if( defined $lastquery && 
 	   $lastquery ne $qname ) {

--- a/t/SearchIO/blasttable.t
+++ b/t/SearchIO/blasttable.t
@@ -7,7 +7,7 @@ BEGIN {
 	use lib '.';
     use Bio::Root::Test;
     
-    test_begin(-tests => 165);
+    test_begin(-tests => 166);
 	
 	use_ok('Bio::SearchIO');
     use_ok('Bio::Search::SearchUtils');
@@ -72,7 +72,8 @@ while(my $res = $searchio->next_result) {
     is($hsp->start('query'), 5);
     is($hsp->end('query'), 812);
     is($hsp->length, 821);
-    is($hsp->gaps, 14);
+    is($hsp->percent_identity, 30.0852618757613, 'fixed bug 3343 (percent identity)');
+    is($hsp->gaps, 44, 'side effect of fixing bug 3343 (number of gaps)');
 	my $hit_sf = $hsp->hit;
 	my $query_sf = $hsp->query;
 	isa_ok($hit_sf, 'Bio::SeqFeatureI');


### PR DESCRIPTION
Hello,

I've updated <code>Bio/SearchIO/blasttable.pm</code> to fix bug 3343 and <code>t/SearchIO/blasttable.t</code> to test it. The only side effect that I see is that when running the blasttable.t tests,  a warning now appears: <code>MSG: Did not define the number of conserved matches in the HSP; assuming conserved == identical (247) </code>. I believe the warning is normal because of the fact that the number of conserved matches in an HSP for blasttable output is not known. 

Thank you,

Paul
