### PR TITLE
to read bl2seq+ output

### DIFF
--- a/Bio/SearchIO/blast.pm
+++ b/Bio/SearchIO/blast.pm
@@ -804,7 +804,7 @@ sub next_result {
         }
 
         # move inside of a hit
-        elsif (/^(Subject=|>)\s*(\S+)\s*(.*)?/) {
+        elsif (/^(?:Subject=|>)\s*(\S+)\s*(.*)?/) {
             chomp;
 
             $self->debug("blast.pm: Hit: $1\n");
@@ -823,8 +823,8 @@ sub next_result {
                 $self->start_element( { 'Name' => 'Iteration' } );
             }
             $self->start_element( { 'Name' => 'Hit' } );
-            my $id         = $2;
-            my $restofline = $3;
+            my $id         = $1;
+            my $restofline = $2;
 
             $self->debug("Starting a hit: $1 $2\n");
             $self->element(


### PR DESCRIPTION
bl2seq from BLAST+ 2.2.29 uses "Subject=" instead of ">" to start hit lines (ex. Subject= gi|2695846....).
