### PR TITLE
Use COLLATE NOCASE instead of LOWER() for Bio::DB::SeqFeature::Store::DBI::SQLite

### DIFF
--- a/Bio/DB/SeqFeature/Store/DBI/SQLite.pm
+++ b/Bio/DB/SeqFeature/Store/DBI/SQLite.pm
@@ -299,14 +299,14 @@ END
 	  typelist => <<END,
 (
   id  integer primary key autoincrement,
-  tag text    not null
+  tag text    not null collate nocase
 );
 create index index_typelist on typelist (tag);
 END
 	  name => <<END,
 (
   id           integer not null,
-  name         text    not null,
+  name         text    not null collate nocase,
   display_name integer default 0
 );
 create index index_name_id on name(id);
@@ -317,7 +317,7 @@ END
 (
   id              integer not null,
   attribute_id    integer not null,
-  attribute_value text
+  attribute_value text collate nocase
 );
 create index index_attribute_id    on attribute(attribute_id);
 create index index_attribute_value on attribute(attribute_value);
@@ -771,7 +771,7 @@ sub _name_sql {
   my $from  = "$name_table as n";
   my ($match,$string) = $self->_match_sql($name);
 
-  my $where = "n.id=$join AND lower(n.name) $match";
+  my $where = "n.id=$join AND n.name $match COLLATE NOCASE";
   $where   .= " AND n.display_name>0" unless $allow_aliases;
   return ($from,$where,'',$string);
 }
@@ -835,8 +835,8 @@ sub _match_sql {
     $match = "LIKE ?";
     $string  = $name;
   } else {
-    $match = "= lower(?)";
-    $string  = lc($name);
+    $match = "= ? COLLATE NOCASE";
+    $string  = $name;
   }
   return ($match,$string);
 }
@@ -888,7 +888,7 @@ sub _types_sql {
     }
 
     if (length $source_tag) {
-      push @matches,"lower(tl.tag)=lower(?)";
+      push @matches,"tl.tag=? COLLATE NOCASE";
       push @args,"$primary_tag:$source_tag";
     } else {
       push @matches,"tl.tag LIKE ?";
@@ -1059,7 +1059,7 @@ sub _genericid {
   my ($table,$namefield,$name,$add_if_missing) = @_;
   my $qualified_table = $self->_qualify($table);
   my $sth = $self->_prepare(<<END);
-SELECT id FROM $qualified_table WHERE lower($namefield)=lower(?)
+SELECT id FROM $qualified_table WHERE $namefield=? COLLATE NOCASE
 END
   $sth->execute($name) or die $sth->errstr;
   my ($id) = $sth->fetchrow_array;
@@ -1118,8 +1118,8 @@ sub _dump_update_name_index {
   my $dbh     = $self->dbh;
   my ($names,$aliases) = $self->feature_names($obj);
   # unlike DBI::mysql, don't quote, as quotes will be quoted when loaded
-  print $fh join("\t",$id,lc($_),1),"\n" foreach @$names;
-  print $fh join("\t",$id,lc($_),0),"\n" foreach @$aliases;
+  print $fh join("\t",$id,$_,1),"\n" foreach @$names;
+  print $fh join("\t",$id,$_,0),"\n" foreach @$aliases;
 }
 
 sub _update_name_index {
@@ -1133,8 +1133,8 @@ sub _update_name_index {
 
   my $sth = $self->_prepare("INSERT INTO $name (id,name,display_name) VALUES (?,?,?)");
 
-  $sth->execute($id,lc $_,1) or $self->throw($sth->errstr)   foreach @$names;
-  $sth->execute($id,lc $_,0) or $self->throw($sth->errstr) foreach @$aliases;
+  $sth->execute($id,$_,1) or $self->throw($sth->errstr)   foreach @$names;
+  $sth->execute($id,$_,0) or $self->throw($sth->errstr) foreach @$aliases;
   $sth->finish;
 }
 


### PR DESCRIPTION
After upgrading from BioPerl 1.6.901 to 1.6.923, a significant performance regression was observed that led to GBrowse timeouts when doing keyword searches. This was traced to the change made to Bio::DB::SeqFeature::Store::DBI::SQLite made in commit d3af015938b88e721658967c9b38ea9e445141e9.

When executing Bio::DB::SeqFeature::Store->get_features_by_name(), The SQL generated by the 1.6.923 version is:

```
SELECT f.id,f.object
  FROM feature as f, name as n
  WHERE (n.id=f.id AND lower(n.name) = lower('M1') AND n.display_name>0)
```

The 1.6.923 query (which uses the LOWER() function on the "name" column) results in a full table scan, while the 1.6.901 method, which omits LOWER(), allows the use of the index on the "name" column:

```
sqlite> explain query plan SELECT f.id,f.object FROM feature as f, name as n WHERE (n.id=f.id AND lower(n.name) = lower('M1') AND n.display_name>0);
0|0|1|SCAN TABLE name AS n
0|1|0|SEARCH TABLE feature AS f USING INTEGER PRIMARY KEY (rowid=?)
sqlite> explain query plan SELECT f.id,f.object FROM feature as f, name as n WHERE (n.id=f.id AND n.name = lower('M1') AND n.display_name>0);
0|0|1|SEARCH TABLE name AS n USING INDEX index_name_name (name=?)
0|1|0|SEARCH TABLE feature AS f USING INTEGER PRIMARY KEY (rowid=?)
```

A more efficient way of achieving a case-insensitive search that allows the use of indexes is to add the COLLATE NOCASE constraint to the relevant columns. This also allows the "LIKE" optimization ( http://www.sqlite.org/optoverview.html ) as well, which in my benchmark database containing 692300 gene/mRNA/CDS features resulted in an almost 7x speedup of Bio::DB::SeqFeature::Store->search_attributes().

The changes in this pull request add the COLLATE NOCASE option to name.name, attribute.attribute_value, and typelist.tag columns, and (for backwards compatibility with existing SeqFeature databases that don't have the COLLATE NOCASE constraint on those columns) replaces the use of the LOWER() function with the COLLATE NOCASE operator.

These changes pass the t/LocalDB/SeqFeature_SQLite.t regression test.
