### PR TITLE
Store Bio::SeqFeature::Lite strand correctly when "+", "-", or "."

### DIFF
--- a/Bio/SeqFeature/Lite.pm
+++ b/Bio/SeqFeature/Lite.pm
@@ -196,9 +196,9 @@ sub new {
 
   $arg{-strand} ||= 0;
   if ($arg{-strand} =~ /^[\+\-\.]$/){
-	$arg{-strand} = "+" && $self->{strand} ='1';
-	$arg{-strand} = "-" && $self->{strand} = '-1';
-	$arg{-strand} = "." && $self->{strand} = '0';
+	($arg{-strand} eq "+") && ($self->{strand} = '1');
+	($arg{-strand} eq "-") && ($self->{strand} = '-1');
+	($arg{-strand} eq ".") && ($self->{strand} = '0');
   } else {
 	  $self->{strand}  = $arg{-strand} ? ($arg{-strand} >= 0 ? +1 : -1) : 0;
   }


### PR DESCRIPTION
The documentation for Bio::SeqFeature::Lite states that the -strand argument
to Bio::SeqFeature::Lite->new() constructor is:

```
    -strand      the strand of the feature (one of -1, 0 or +1)
```

However, an attempt is made to handle "+", "-", and "." arguments as well:

```
  $arg{-strand} ||= 0;
  if ($arg{-strand} =~ /^[\+\-\.]$/){
    $arg{-strand} = "+" && $self->{strand} ='1';
    $arg{-strand} = "-" && $self->{strand} = '-1';
    $arg{-strand} = "." && $self->{strand} = '0';
  } else {
      $self->{strand}  = $arg{-strand} ? ($arg{-strand} >= 0 ? +1 : -1) : 0;
  }
```

This attempt fails, however, due to the use of the assignment operator (=)
instead of stringwise equality operator (eq); e.g., the following script

```
#!/usr/bin/env perl
use warnings;
use strict;
use Bio::SeqFeature::Lite;

my $f_pos = Bio::SeqFeature::Lite->new(-start => 1000,-stop => 2000,-strand => '+');
my $f_neg = Bio::SeqFeature::Lite->new(-start => 1000,-stop => 2000,-strand => '-');
my $f_none = Bio::SeqFeature::Lite->new(-start => 1000,-stop => 2000,-strand => '.');

print "f_pos: " . $f_pos->strand() . "\n";
print "f_neg: " . $f_neg->strand() . "\n";
print "f_none: " . $f_none->strand() . "\n";
```

results in the following output:

```
f_pos: 0
f_neg: 0
f_none: 0
```

After the proposed patch, the output of the script is:

```
f_pos: 1
f_neg: -1
f_none: 0
```
