### PR TITLE
Localize Storable options used by Bio::DB::SeqFeature::Store

### DIFF
--- a/Bio/DB/SeqFeature/Store.pm
+++ b/Bio/DB/SeqFeature/Store.pm
@@ -2477,6 +2477,7 @@ sub freeze {
     my $d    = Data::Dumper->new([$obj]);
     $d->Terse(1);
     $d->Deepcopy(1);
+    $d->Deparse(1);
     $data = $d->Dump;
   } elsif ($serializer eq 'Storable') {
     local $Storable::forgive_me = 1;


### PR DESCRIPTION
Globally setting `$Storable::{Deparse,Eval} = 1` is a security risk for unsuspecting third party code relying on the Storable defaults.

This branch also includes a small change to the Data::Dumper serializer support so it will also deparse sub refs.
