### PR TITLE
BUGFIX to Bio::DB::GenericWebAgent that allows -file to accept more perl-like write-append type data

### DIFF
--- a/Bio/DB/GenericWebAgent.pm
+++ b/Bio/DB/GenericWebAgent.pm
@@ -361,9 +361,7 @@ sub _dump_request_content {
     require Bio::Root::IO;
     # If $file was NOT specified in write ">" or append ">>" mode, then
     # assume that the file should be opened in write mode. 
-    if( $file !~ /^>/){
-        $file = ">$file";
-    } 
+    $file = ">$file" if $file !~ /^>/;
     my $out = Bio::Root::IO->new(-file => $file);
     $out->_print($self->{_response_cache}->content);
     $out->flush();


### PR DESCRIPTION
I was following examples in the EUtilities Cookbook (http://www.bioperl.org/wiki/HOWTO:EUtilities_Cookbook) to try and fetch genbank sequences.  I wanted to append to an output file, but this did not work so I made the following fix.

Bio::DB::EUtilities uses as its base class Bio::DB::GenericWebAgent, so this is a minor bugfix made to Bio::DB::GenericWebAgent that allows "-file to accept more perl-like write-append type data."

The following will write to a file:
$factory->get_Response(-file => 'file.gb');
$factory->get_Response(-file => '>newFile.gb');

The following will append to a file:
$factory->get_Response(-file => '>>appendedFile.gb');
