### PR TITLE
Stop masking $seq variable in entrezgene.pm next_seq

### DIFF
--- a/Bio/SeqIO/entrezgene.pm
+++ b/Bio/SeqIO/entrezgene.pm
@@ -196,7 +196,7 @@ sub next_seq {
 
     #Basic data
     #$xval->{summary}=~s/\n//g;
-    my $seq = Bio::Seq->new(
+    $seq = Bio::Seq->new(
         -display_id       => $xval->{gene}{locus},
         -accession_number => $xval->{'track-info'}{geneid},
         -desc             => $xval->{summary}


### PR DESCRIPTION
$seq is decalared at line 151 so that it doesn't have to be passed as an argument to subs. However, at line 199, in the next_seq sub, $seq is declared again such that the original $seq variable is never defined. As far as I can tell this works in practice because for the most part $seq is only accessed in the next_seq sub. However, if you run into a variable without a tagname and try to throw the warning at line 571 your script dies with an error when trying to call method 'id' on an undefined variable. This suggested fix is simply to stop re-declaring $seq at line 199.