### PR TITLE
Accept space after equal sign in qualifiers when reading EMBL.

### DIFF
--- a/Bio/SeqIO/embl.pm
+++ b/Bio/SeqIO/embl.pm
@@ -1358,7 +1358,7 @@ sub _read_FTHelper_EMBL {
     # intact to provide informative error messages.)
   QUAL: for (my $i = 0; $i < @qual; $i++) {
         $_ = $qual[$i];
-        my( $qualifier, $value ) = m{^/([^=]+)(?:=(.+))?}
+        my( $qualifier, $value ) = m{^/([^=]+)(?:=\s*(.+))?}
             or $self->throw("Can't see new qualifier in: $_\nfrom:\n"
                             . join('', map "$_\n", @qual));
         if (defined $value) {

--- a/t/SeqIO/embl.t
+++ b/t/SeqIO/embl.t
@@ -8,7 +8,7 @@ BEGIN {
     use lib '../..';
     use Bio::Root::Test;
 
-    test_begin(-tests => 96);
+    test_begin(-tests => 100);
 
     use_ok('Bio::SeqIO::embl');
 }
@@ -327,4 +327,22 @@ foreach my $feature ($seq->top_SeqFeatures) {
     $out->write_seq($seq);
 
     ok($string =~ m/ID   test_id;/, "The ID field was written correctly");
+}
+
+# Test lenient handling of space after '=' sign in qualifiers:
+{
+    my $ent = Bio::SeqIO->new( -file => test_input_file('test_space.embl'),
+                               -format => 'embl');
+    my $seq;
+    eval { $seq = $ent->next_seq(); };
+    my $error=$@;
+    is($error, '', 'EMBL format with space after equal sign parses');
+
+    my ($feature)=$seq->all_SeqFeatures;
+    is($feature->primary_tag, 'CDS', 'CDS read');
+
+    ok($feature->has_tag('product'), '/product found');
+
+    my ($value)=$feature->get_tag_values('product');
+    is($value, 'somewordandt extthatisquite lon gandthereforewraps', 'Qualifier /product value matches');
 }

--- a/t/data/test_space.embl
+++ b/t/data/test_space.embl
@@ -1,0 +1,19 @@
+ID   TEST standard; DNA; 10 BP.
+XX
+AC   TEST;
+XX
+DT   09-APR-2015
+XX
+DE   Test of space before quoted qualifier.
+XX
+XX
+FH   Key             Location/Qualifiers
+FT   CDS             1..10
+FT                   /*tag= x
+FT                   /gene= "someT"
+FT                   /product= "somewordandt extthatisquite lon
+FT                   gandthereforewraps"
+XX
+SQ   Sequence 10 BP; 10 A; 0 C; 0 G; 9 T; 0 U; 0 Other;
+     aaaaaaaaaa       10
+//


### PR DESCRIPTION
This makes /product= "some long ... value" read as if the space
after the '=' was not there; this formatting has been observed
in the wild.

As discussed on the mailing list: http://thread.gmane.org/gmane.comp.lang.perl.bio.general/27453