### PR TITLE
Bugfix in the Stockholm AlignIO writer

### DIFF
--- a/Bio/AlignIO/stockholm.pm
+++ b/Bio/AlignIO/stockholm.pm
@@ -597,7 +597,7 @@ sub write_aln {
     my $tag = 'AC';
     for my $seq ($aln->each_seq) {
         if (my $acc = $seq->accession_number) {
-	    my $text = sprintf("%-4s%-22s%-3s%s\n",$seq_ann,
+	    my $text = sprintf("%-4s%-22s %-3s%s\n",$seq_ann,
 			       $aln->displayname($seq->get_nse), $tag, $acc);
 	    $self->_print($text) || return 0;
         }


### PR DESCRIPTION
With the previous code, the name of a sequence can be attached to "AC" if it is 22 (or more) characters long
fix: make sure there is at least 1 space between the sequence name and the "AC" tag