### PR TITLE
don't hang on parsing fasta36 -m 9 output

### DIFF
--- a/Bio/SearchIO/fasta.pm
+++ b/Bio/SearchIO/fasta.pm
@@ -1094,7 +1094,7 @@ sub next_result {
                     $self->_pushback($_);
                     last;
                 }
-                elsif (/^>>>(\*\*\*|\\\\\\|<<<)/o) {
+                elsif (/^>>>(\*\*\*|\/\/\/|<<<)/o) {
                     $self->end_element( { Name => "Hsp" } );
                     last;
                 }

--- a/Bio/SearchIO/fasta.pm
+++ b/Bio/SearchIO/fasta.pm
@@ -1094,7 +1094,7 @@ sub next_result {
                     $self->_pushback($_);
                     last;
                 }
-                elsif (/^>>>\*\*\*/o) {
+                elsif (/^>>>(\*\*\*|\\\\\\|<<<)/o) {
                     $self->end_element( { Name => "Hsp" } );
                     last;
                 }


### PR DESCRIPTION
Hello,

I've bumped on a problem where bioperl hangs when reading an output generated by fasta36.
Here's an example: http://karasik.eu.org/misc/fasta.txt

Seems that the problem is with fasta36 (vs fasta34) adds >>><<< and >>>/// markings that don't go well with bioperl.

Sincerely,
Dmitry

