### PR TITLE
Allow SearchIO::hmmer3 to parse output from phmmer

### DIFF
--- a/Bio/SearchIO/hmmer3.pm
+++ b/Bio/SearchIO/hmmer3.pm
@@ -36,7 +36,7 @@ print $hsp->start('hit'), $hsp->end('hit'), $hsp->start('query'),
 
 =head1 DESCRIPTION
 
-Code to parse output from hmmsearch, hmmscan, and nhmmer, compatible with
+Code to parse output from hmmsearch, hmmscan, phmmer and nhmmer, compatible with
 both version 2 and version 3 of the HMMER package from L<http://hmmer.org>.
 
 =head1 FEEDBACK
@@ -218,6 +218,7 @@ sub next_result {
         # Get the query info
         elsif ( $buffer =~ /^\#\squery (?:\w+ )?file\:\s+(\S+)/ ) {
             if (   $self->{'_reporttype'} eq 'HMMSEARCH'
+                || $self->{'_reporttype'} eq 'PHMMER'
                 || $self->{'_reporttype'} eq 'NHMMER' )
             {
                 $self->{'_hmmfileline'} = $lineorig;
@@ -246,6 +247,7 @@ sub next_result {
         elsif ( $buffer =~ m/^\#\starget\s\S+\sdatabase\:\s+(\S+)/ ) {
 
             if (   $self->{'_reporttype'} eq 'HMMSEARCH'
+                || $self->{'_reporttype'} eq 'PHMMER'
                 || $self->{'_reporttype'} eq 'NHMMER' )
             {
                 $self->{'_hmmseqline'} = $lineorig;
@@ -293,6 +295,7 @@ sub next_result {
                      )
                 ) {
                 if (   $self->{'_reporttype'} eq 'HMMSEARCH'
+                    or $self->{'_reporttype'} eq 'PHMMER'
                     or $self->{'_reporttype'} eq 'NHMMER'
                     ) {
                     my ($qry_file)    = $self->{_hmmfileline} =~ m/^\#\squery (?:\w+ )?file\:\s+(\S+)/;
@@ -366,6 +369,7 @@ sub next_result {
             defined $self->{'_reporttype'}
             && (   $self->{'_reporttype'} eq 'HMMSEARCH'
                 || $self->{'_reporttype'} eq 'HMMSCAN'
+                || $self->{'_reporttype'} eq 'PHMMER'
                 || $self->{'_reporttype'} eq 'NHMMER' )
             )
         {
@@ -552,7 +556,7 @@ sub next_result {
                             }
 
                             # Grab hsp data from table, push into @hsp;
-                            if ($self->{'_reporttype'} =~ m/(?:HMMSCAN|HMMSEARCH|NHMMER)/) {
+                            if ($self->{'_reporttype'} =~ m/(?:HMMSCAN|HMMSEARCH|PHMMER|NHMMER)/) {
                                 my ( $domain_num, $score,    $bias,
                                      $ceval,      $ieval,
                                      $hmm_start,  $hmm_stop, $hmm_cov,
@@ -583,7 +587,7 @@ sub next_result {
 
                                     # Try to get the Hit length from the alignment information
                                     $hitlength = 0;
-                                    if ($self->{'_reporttype'} eq 'HMMSEARCH') {
+                                    if ($self->{'_reporttype'} eq 'HMMSEARCH' || $self->{'_reporttype'} eq 'PHMMER') {
                                         # For Hmmsearch, if seq coverage ends in ']' it means that the alignment
                                         # runs until the end. In that case add the END coordinate to @hitinfo
                                         # to use it as Hit Length
@@ -1045,7 +1049,7 @@ sub end_element {
     my $rc;
 
     if ( $nm eq 'HMMER_program' ) {
-        if ( $self->{'_last_data'} =~ /(N?HMM\S+)/i ) {
+        if ( $self->{'_last_data'} =~ /([NP]?HMM\S+)/i ) {
             $self->{'_reporttype'} = uc $1;
         }
     }

--- a/t/SearchIO/hmmer.t
+++ b/t/SearchIO/hmmer.t
@@ -7,7 +7,7 @@ BEGIN {
     use lib '.';
     use Bio::Root::Test;
 
-    test_begin( -tests => 817 );
+    test_begin( -tests => 824 );
 
     use_ok('Bio::SearchIO');
 }
@@ -1683,3 +1683,30 @@ $searchio = Bio::SearchIO->new(
 );
 eval { $searchio->next_result; };
 is( $@, '', 'Correct parsing of alignments with stops' );
+
+
+# Test for correct parsing of phmmer results
+# Without the patch, parsing skips all lines from phmmer output
+{
+	my $searchio = Bio::SearchIO->new(
+		-format => 'hmmer',
+		-file   => test_input_file('phmmer.out')
+	);
+	
+	my $result = $searchio->next_result;
+	if ( defined $result ) {
+
+		is( $result->algorithm,         'PHMMER',  'Check algorithm' );
+		is( $result->query_name,        'A0R3R7',  'Check query_name' );
+		is( $result->query_length,       762,      'Check query_length absence' );
+		is( $result->query_description, '',        'Check query_description' );
+		is( $result->num_hits(),         8,        'Check num_hits' );
+
+		my $hit = $result->next_model;
+		if ( defined $hit ) {
+			is( $hit->name, 'cath|4_0_0|1vs0A03/639-759', 'query name okay' );
+			is( $hit->num_hsps(), 1, 'Check num_hsps' );
+		}
+	}
+
+}

--- a/t/data/phmmer.out
+++ b/t/data/phmmer.out
@@ -1,0 +1,183 @@
+# phmmer :: search a protein sequence against a protein database
+# HMMER 3.1b1 (May 2013); http://hmmer.org/
+# Copyright (C) 2013 Howard Hughes Medical Institute.
+# Freely distributed under the GNU General Public License (GPLv3).
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# query sequence file:             /tmp/task-hmmsearch-TCHn9R/ZRkI2xwebU
+# target sequence database:        /cath/data/v4_0_0/release_data/CathDomainSeqs.COMBS
+# output directed to file:         /tmp/phmmer.out
+# sequence reporting threshold:    E-value <= 0.01
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+Query:       A0R3R7  [L=762]
+Scores for complete sequences (score includes all domains):
+   --- full sequence ---   --- best 1 domain ---    -#dom-
+    E-value  score  bias    E-value  score  bias    exp  N  Sequence                           Description
+    ------- ------ -----    ------- ------ -----   ---- --  --------                           -----------
+    2.1e-55  191.8   3.7    2.3e-55  191.7   3.7    1.0  1  cath|4_0_0|1vs0A03/639-759          
+    2.1e-55  191.8   3.7    2.3e-55  191.7   3.7    1.0  1  cath|4_0_0|1vs0B03/639-759          
+    1.9e-46  162.2   0.2    2.1e-46  162.1   0.2    1.0  1  cath|4_0_0|1vs0A02/484-593          
+    1.9e-46  162.2   0.2    2.1e-46  162.1   0.2    1.0  1  cath|4_0_0|1vs0B02/484-593          
+    5.8e-17   64.7   1.4    7.1e-10   41.3   0.1    2.0  2  cath|4_0_0|1vs0A01/453-483_594-638  
+    5.8e-17   64.7   1.4    7.1e-10   41.3   0.1    2.0  2  cath|4_0_0|1vs0B01/453-483_594-638  
+    6.4e-07   31.5   0.1    8.1e-07   31.2   0.1    1.0  1  cath|4_0_0|2cfmA03/422-561          
+    0.00065   21.6   0.0    0.00069   21.5   0.0    1.0  1  cath|4_0_0|1x9nA03/571-696          
+
+
+Domain annotation for each sequence (and alignments):
+>> cath|4_0_0|1vs0A03/639-759  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  191.7   3.7   7.9e-60   2.3e-55     642     761 ..       1     120 [.       1     121 [] 0.99
+
+  Alignments for each domain:
+  == domain 1  score: 191.7 bits;  conditional E-value: 7.9e-60
+                      A0R3R7 642 wntqevviggwrqgeggrssgigalvlgipgpeglqfvgrvgtgftekelsklkdmlkplhtdespfnaplpkvdargvtfvr 724
+                                 wntqevviggwr geggrssg+g+l+ gipgp glqf grvgtg++e+el+ lk+ l plhtdespf+ plp  da+g+t+v+
+  cath|4_0_0|1vs0A03/639-759   1 WNTQEVVIGGWRAGEGGRSSGVGSLLXGIPGPGGLQFAGRVGTGLSERELANLKEXLAPLHTDESPFDVPLPARDAKGITYVK 83 
+                                 *********************************************************************************** PP
+
+                      A0R3R7 725 pelvgevrysertsdgrlrqpswrglrpdktpdevvw 761
+                                 p lv+evryse t +grlrq swrglrpdk p evv 
+  cath|4_0_0|1vs0A03/639-759  84 PALVAEVRYSEWTPEGRLRQSSWRGLRPDKKPSEVVR 120
+                                 ***********************************96 PP
+
+>> cath|4_0_0|1vs0B03/639-759  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  191.7   3.7   7.9e-60   2.3e-55     642     761 ..       1     120 [.       1     121 [] 0.99
+
+  Alignments for each domain:
+  == domain 1  score: 191.7 bits;  conditional E-value: 7.9e-60
+                      A0R3R7 642 wntqevviggwrqgeggrssgigalvlgipgpeglqfvgrvgtgftekelsklkdmlkplhtdespfnaplpkvdargvtfvr 724
+                                 wntqevviggwr geggrssg+g+l+ gipgp glqf grvgtg++e+el+ lk+ l plhtdespf+ plp  da+g+t+v+
+  cath|4_0_0|1vs0B03/639-759   1 WNTQEVVIGGWRAGEGGRSSGVGSLLXGIPGPGGLQFAGRVGTGLSERELANLKEXLAPLHTDESPFDVPLPARDAKGITYVK 83 
+                                 *********************************************************************************** PP
+
+                      A0R3R7 725 pelvgevrysertsdgrlrqpswrglrpdktpdevvw 761
+                                 p lv+evryse t +grlrq swrglrpdk p evv 
+  cath|4_0_0|1vs0B03/639-759  84 PALVAEVRYSEWTPEGRLRQSSWRGLRPDKKPSEVVR 120
+                                 ***********************************96 PP
+
+>> cath|4_0_0|1vs0A02/484-593  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  162.1   0.2     7e-51   2.1e-46     487     596 ..       1     110 []       1     110 [] 0.99
+
+  Alignments for each domain:
+  == domain 1  score: 162.1 bits;  conditional E-value: 7e-51
+                      A0R3R7 487 gyrviidadhgqlqirsrtgrevtgeypqfkalaadlaehhvvldgeavaldesgvpsfgqmqnrarstrvefwafdilwldg 569
+                                 gyr++++adhg +++rsr+gr+vt+eypq++ala dla+hhvvldgeav ld sgvpsf+q qnr r trvefwafd+l+ldg
+  cath|4_0_0|1vs0A02/484-593   1 GYRLLVEADHGAVRLRSRSGRDVTAEYPQLRALAEDLADHHVVLDGEAVVLDSSGVPSFSQXQNRGRDTRVEFWAFDLLYLDG 83 
+                                 8********************************************************************************** PP
+
+                      A0R3R7 570 rsllrakysdrrkilealadggglivp 596
+                                 r+ll  +y drrk+le la++ +l vp
+  cath|4_0_0|1vs0A02/484-593  84 RALLGTRYQDRRKLLETLANATSLTVP 110
+                                 *********************999998 PP
+
+>> cath|4_0_0|1vs0B02/484-593  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !  162.1   0.2     7e-51   2.1e-46     487     596 ..       1     110 []       1     110 [] 0.99
+
+  Alignments for each domain:
+  == domain 1  score: 162.1 bits;  conditional E-value: 7e-51
+                      A0R3R7 487 gyrviidadhgqlqirsrtgrevtgeypqfkalaadlaehhvvldgeavaldesgvpsfgqmqnrarstrvefwafdilwldg 569
+                                 gyr++++adhg +++rsr+gr+vt+eypq++ala dla+hhvvldgeav ld sgvpsf+q qnr r trvefwafd+l+ldg
+  cath|4_0_0|1vs0B02/484-593   1 GYRLLVEADHGAVRLRSRSGRDVTAEYPQLRALAEDLADHHVVLDGEAVVLDSSGVPSFSQXQNRGRDTRVEFWAFDLLYLDG 83 
+                                 8********************************************************************************** PP
+
+                      A0R3R7 570 rsllrakysdrrkilealadggglivp 596
+                                 r+ll  +y drrk+le la++ +l vp
+  cath|4_0_0|1vs0B02/484-593  84 RALLGTRYQDRRKLLETLANATSLTVP 110
+                                 *********************999998 PP
+
+>> cath|4_0_0|1vs0A01/453-483_594-638  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   24.0   0.1   4.2e-09   0.00012     459     487 ..       7      35 ..       4      37 .. 0.93
+   2 !   41.3   0.1   2.4e-14   7.1e-10     598     640 ..      36      78 ..      34      79 .] 0.96
+
+  Alignments for each domain:
+  == domain 1  score: 24.0 bits;  conditional E-value: 4.2e-09
+                              A0R3R7 459 edfapmlategsvakykakqwafegkwdg 487
+                                         +++ap lat g+va  ka qwafeg wd 
+  cath|4_0_0|1vs0A01/453-483_594-638   7 DNLAPXLATHGTVAGLKASQWAFEGXWDE 35 
+                                         578************************95 PP
+
+  == domain 2  score: 41.3 bits;  conditional E-value: 2.4e-14
+                              A0R3R7 598 qlpgdgpeamehvrkkrfegvvakkwdstyqpgrrssswikdk 640
+                                          lpgdg +a+   rk  +egv+ak+ ds yqpgrr +sw+kdk
+  cath|4_0_0|1vs0A01/453-483_594-638  36 LLPGDGAQAFACSRKHGWEGVIAKRRDSRYQPGRRCASWVKDK 78 
+                                         69****************************************8 PP
+
+>> cath|4_0_0|1vs0B01/453-483_594-638  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   24.0   0.1   4.2e-09   0.00012     459     487 ..       7      35 ..       4      37 .. 0.93
+   2 !   41.3   0.1   2.4e-14   7.1e-10     598     640 ..      36      78 ..      34      79 .] 0.96
+
+  Alignments for each domain:
+  == domain 1  score: 24.0 bits;  conditional E-value: 4.2e-09
+                              A0R3R7 459 edfapmlategsvakykakqwafegkwdg 487
+                                         +++ap lat g+va  ka qwafeg wd 
+  cath|4_0_0|1vs0B01/453-483_594-638   7 DNLAPXLATHGTVAGLKASQWAFEGXWDE 35 
+                                         578************************95 PP
+
+  == domain 2  score: 41.3 bits;  conditional E-value: 2.4e-14
+                              A0R3R7 598 qlpgdgpeamehvrkkrfegvvakkwdstyqpgrrssswikdk 640
+                                          lpgdg +a+   rk  +egv+ak+ ds yqpgrr +sw+kdk
+  cath|4_0_0|1vs0B01/453-483_594-638  36 LLPGDGAQAFACSRKHGWEGVIAKRRDSRYQPGRRCASWVKDK 78 
+                                         69****************************************8 PP
+
+>> cath|4_0_0|2cfmA03/422-561  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   31.2   0.1   2.7e-11   8.1e-07     646     758 ..       8     117 ..       2     120 .. 0.80
+
+  Alignments for each domain:
+  == domain 1  score: 31.2 bits;  conditional E-value: 2.7e-11
+                      A0R3R7 646 evviggwrqgeggrssgigalvlgipgpeglqf..vgrvgtgftekelsklkdmlkplhtdespfnapl.pkvdargvtfvrp 725
+                                 ++vi g + geg r+  +g+++lg   pe  +f  vg+vg+gft+ +l ++   lkpl   e      l pkv    vt+   
+  cath|4_0_0|2cfmA03/422-561   8 DLVIIGAEWGEGRRAHLFGSFILGAYDPETGEFleVGKVGSGFTDDDLVEFTKXLKPLIIKEEGKRVWLqPKVV-IEVTYQ-- 87 
+                                 456667789********************9888667**********************9988877776636664.446663.. PP
+
+                      A0R3R7 726 elvgevrysertsdgrlrqpswrglrpdktpde 758
+                                 e+    +y    s   lr p + +lr dk p++
+  cath|4_0_0|2cfmA03/422-561  88 EIQKSPKY---RSGFALRFPRFVALRDDKGPED 117
+                                 44444444...355689************9987 PP
+
+>> cath|4_0_0|1x9nA03/571-696  
+   #    score  bias  c-Evalue  i-Evalue hmmfrom  hmm to    alifrom  ali to    envfrom  env to     acc
+ ---   ------ ----- --------- --------- ------- -------    ------- -------    ------- -------    ----
+   1 !   21.5   0.0   2.3e-08   0.00069     494     585 ..       9     113 ..       1     124 [. 0.74
+
+  Alignments for each domain:
+  == domain 1  score: 21.5 bits;  conditional E-value: 2.3e-08
+                      A0R3R7 494 adhgqlqirsrtgrevtgeypqfkalaadlae...hhvvldgeavalde..sgvpsfgqmqnrars........trvefwafd 563
+                                  + g+++i sr  ++ tg+yp + +    +        +ld eava d     +  f  +  r r          +v ++afd
+  cath|4_0_0|1x9nA03/571-696   9 LEGGEVKIFSRNQEDNTGKYPDIISRIPKIKLpsvTSFILDTEAVAWDRekKQIQPFQVLTTRKRKevdaseiqVQVCLYAFD 91 
+                                 36799*****************98776665430114679*******9962256889998888877422222211345589*** PP
+
+                      A0R3R7 564 ilwldgrsllrakysdrrkile 585
+                                 +++l+g+sl+r   s rr++l 
+  cath|4_0_0|1x9nA03/571-696  92 LIYLNGESLVREPLSRRRQLLR 113
+                                 ******************9985 PP
+
+
+
+Internal pipeline statistics summary:
+-------------------------------------
+Query model(s):                              1  (762 nodes)
+Target sequences:                       235858  (38973128 residues searched)
+Passed MSV filter:                      6997  (0.0296662); expected 4717.2 (0.02)
+Passed bias filter:                     6066  (0.0257189); expected 4717.2 (0.02)
+Passed Vit filter:                       317  (0.00134403); expected 235.9 (0.001)
+Passed Fwd filter:                         9  (3.81586e-05); expected 2.4 (1e-05)
+Initial search space (Z):             235858  [actual number of targets]
+Domain search space  (domZ):               8  [number of targets reported over threshold]
+# CPU time: 4.10u 0.03s 00:00:04.13 Elapsed: 00:00:00.62
+# Mc/sec: 47899.23
+//
+[ok]


### PR DESCRIPTION
Currently SearchIO::hmmer3 skips all lines when parsing phmmer output - but at first glance, the format looks very similar (identical?) to hmmsearch. I've added a few tweaks to enable phmmer output to be parsed like hmmsearch and a test to check that the output looks vaguely sensible. 