### PR TITLE
remove my redeclaration that fails with perl 5.23.2

### DIFF
--- a/Bio/Tools/Alignment/Consed.pm
+++ b/Bio/Tools/Alignment/Consed.pm
@@ -1709,7 +1709,7 @@ Recursion is kewl, but this sub should likely be _reverse_recurse.
 
 
 sub reverse_recurse($$) {
-    my ($r_source,my $r_destination) = @_;
+    my ($r_source,$r_destination) = @_;
     if (!@$r_source) {
         return $r_destination;
     }


### PR DESCRIPTION
redeclaration of my is deprecated in perl 5.23.2. This causes t/Tools/Alignment/Consed.t  to fail:

```
Failed test 'use Bio::Tools::Alignment::Consed;'
at t/Tools/Alignment/Consed.t line 19.
Tried to use 'Bio::Tools::Alignment::Consed'.
Error:  Can't redeclare "my" in "my" at Bio/Tools/Alignment/Consed.pm line 1712, at end of line
```

Removal of my redeclaration fixes error and allows test to pass.