### PR TITLE
fix IDs per Issue #137 when making DNAaln objects

### DIFF
--- a/Bio/Align/Utilities.pm
+++ b/Bio/Align/Utilities.pm
@@ -148,13 +148,12 @@ sub aa_to_dna_aln {
 
     foreach my $seq ( $aln->each_seq ) {
         my $aa_seqstr = $seq->seq();
-        my $id        = $seq->display_id;
-        my $dnaseq =
-          $dnaseqs->{$id} || $aln->throw( "cannot find " . $seq->display_id );
+        my $pepid     = $seq->display_id;
+        my $dnaseq    = $dnaseqs->{$pepid} || $aln->throw( "cannot find " . $seq->display_id );
         my $start_offset = ( $seq->start - 1 ) * CODONSIZE;
-
         $dnaseq = $dnaseq->seq();
-        my $dnalen = $dnaseqs->{$id}->length;
+        my $dnalen = $dnaseqs->{$pepid}->length;
+        my $dnaid = $dnaseqs->{$pepid}->display_id || $pepid; # try to use DNAseq obj ID (issue #137)
         my $nt_seqstr;
         my $j = 0;
         for ( my $i = 0 ; $i < $alnlen ; $i++ ) {
@@ -170,7 +169,7 @@ sub aa_to_dna_aln {
         $nt_seqstr .= $GAP x ( ( $alnlen * 3 ) - length($nt_seqstr) );
 
         my $newdna = Bio::LocatableSeq->new(
-            -display_id => $id,
+            -display_id => $dnaid,
             -alphabet   => 'dna',
             -start      => $start_offset + 1,
             -end        => ( $seq->end * CODONSIZE ),

--- a/t/Align/Utilities.t
+++ b/t/Align/Utilities.t
@@ -7,7 +7,7 @@ BEGIN {
 	use lib '.';
     use Bio::Root::Test;
     
-    test_begin(-tests => 13);
+    test_begin(-tests => 14);
 	
 	use_ok('Bio::Align::Utilities', qw(:all));
 	use_ok('Bio::SimpleAlign');
@@ -24,9 +24,9 @@ $aa_align->add_seq(Bio::LocatableSeq->new(-id => "n2", -seq => "MLIDVRTPLALR"));
 $aa_align->add_seq(Bio::LocatableSeq->new(-id => "n3", -seq => "MLI-VR-SLALR"));
 
 my %dnaseqs = ();
-$dnaseqs{'n1'} = Bio::PrimarySeq->new(-id => "n1", -seq => 'atgctgatagacgtaggcatgctagtactgaga');
-$dnaseqs{'n2'} = Bio::PrimarySeq->new(-id => "n2", -seq => 'atgctgatcgacgtacgcaccccgctagcactcaga');
-$dnaseqs{'n3'} = Bio::PrimarySeq->new(-id => "n3", -seq => 'atgttgattgtacgctcgcttgcacttaga');
+$dnaseqs{'n1'} = Bio::PrimarySeq->new(-id => "n1dna", -seq => 'atgctgatagacgtaggcatgctagtactgaga');
+$dnaseqs{'n2'} = Bio::PrimarySeq->new(-id => "n2dna", -seq => 'atgctgatcgacgtacgcaccccgctagcactcaga');
+$dnaseqs{'n3'} = Bio::PrimarySeq->new(-id => "n3dna", -seq => 'atgttgattgtacgctcgcttgcacttaga');
 my $dna_aln;
 
 ok( $dna_aln = &aa_to_dna_aln($aa_align, \%dnaseqs));
@@ -39,6 +39,8 @@ is $dna_aln->num_residues, 99;
 is $dna_aln->num_sequences, 3;
 is $dna_aln->consensus_string(50), "atgctgat?gacgtacgc????cgctagcact?aga";
 
+my @dnaseqs = $dna_aln->each_seq;
+is $dnaseqs[0]->display_id, 'n1dna';
 $dna_aln->verbose(-1);
 my $replicates;
 ok $replicates = &bootstrap_replicates($dna_aln,3);


### PR DESCRIPTION
for aa_to_dna_aln - use the display id for to the DNAseq object not the key in the hash which links proteins to DNA when making then new DNA (well CDS) alignment object.