### PR TITLE
Fix for the Disease Ontology OBO file 'def' lines

### DIFF
--- a/Bio/OntologyIO/obo.pm
+++ b/Bio/OntologyIO/obo.pm
@@ -813,7 +813,7 @@ sub _to_annotation {
     return unless $links;
     my @dbxrefs;
     for my $string (@{$links}) {
-        my ($db, $id) = split(':',$string);
+        my ($db, $id) = split(':',$string,2);
         push @dbxrefs, Bio::Annotation::DBLink->new(-database => $db, -primary_id => $id);
     }
 


### PR DESCRIPTION
The [Disease Ontology OBO file](http://purl.obolibrary.org/obo/doid.obo) is causing issues for the Bio::OntologyIO::obo parser due to the use of URLs in the def line attributions.  For example, the term angiosarcoma below is parsed so that the def line URLs result in an array of DBLink objects with the database set to 'url' and primary_id set to 'http'.

```
[Term]
id: DOID:0001816
name: angiosarcoma
alt_id: DOID:267
alt_id: DOID:4508
def: "A malignant vascular tumor that results_in rapidly proliferating, extensively infiltrating anaplastic cells derived_from blood vessels and derived_from the lining of irregular blood-filled spaces." [url:http\://emedicine.medscape.com/article/276512-overview, url:http\://en.wikipedia.org/wiki/Hemangiosarcoma, url:http\://www.ncbi.nlm.nih.gov/pubmed/23327728]
subset: NCIthesaurus
synonym: "hemangiosarcoma" EXACT []
xref: MSH:D006394
xref: NCI:C3088
xref: NCI:C9275
xref: SNOMEDCT_US_2015_03_01:33176006
xref: SNOMEDCT_US_2015_03_01:39000009
xref: SNOMEDCT_US_2015_03_01:403977003
xref: UMLS_CUI:C0018923
xref: UMLS_CUI:C0854893
is_a: DOID:1115 ! sarcoma
```

When parsing the entire DO OBO file, this results in thousands of warning messages.

```
--------------------- WARNING ---------------------
MSG: DBLink exists in the dblink of _default
---------------------------------------------------
 at /usr/share/perl5/Bio/Root/RootI.pm line 169, <$_[...]> line 105500.
        Bio::Root::RootI::warn(Bio::Ontology::OBOterm=HASH(0x5dc8ce0), "DBLink exists in the dblink of _default") called at /usr/share/perl5/Bio/Ontology/Term.pm line 559
        Bio::Ontology::Term::add_dbxref(Bio::Ontology::OBOterm=HASH(0x5dc8ce0), "-dbxrefs", ARRAY(0x5dc3b70)) called at /usr/share/perl5/Bio/OntologyIO/obo.pm line 661
        Bio::OntologyIO::obo::_next_term(Bio::OntologyIO::obo=HASH(0x396c9c8)) called at /usr/share/perl5/Bio/OntologyIO/obo.pm line 237
        Bio::OntologyIO::obo::parse(Bio::OntologyIO::obo=HASH(0x396c9c8)) called at /usr/share/perl5/Bio/OntologyIO/obo.pm line 341
        Bio::OntologyIO::obo::next_ontology(Bio::OntologyIO::obo=HASH(0x396c9c8)) called at /g2f/bin/load_DO.pl line 76
```

Adding a limit to the split in the Bio::OntologyIO::obo::_to_annotation sub prevents the full URL from being discarded.