### PR TITLE
Avoid "Unescaped left brace in regex is deprecated" warning.

### DIFF
--- a/Bio/Tools/SiRNA/Ruleset/tuschl.pm
+++ b/Bio/Tools/SiRNA/Ruleset/tuschl.pm
@@ -178,8 +178,9 @@ sub _get_oligos {
 	    my $target = $2;
 
 	    # check for too many Gs (or Cs on the other strand)
-	    next if ( $target =~ /G{ $self->gstring,}/io );
-	    next if ( $target =~ /C{ $self->gstring,}/io );
+	    my $max_g = $self->gstring;
+	    next if ( $target =~ /G{$max_g,}/io );
+	    next if ( $target =~ /C{$max_g,}/io );
 # 	skip Ns (for filtering)
 	    next if ( $target =~ /N/i);
 

--- a/t/Tools/SiRNA.t
+++ b/t/Tools/SiRNA.t
@@ -30,7 +30,7 @@ isa_ok( $sirna, 'Bio::Tools::SiRNA' ) ;
 
 # first test - cds only
 my @pairs = $sirna->design;
-is ( scalar(@pairs), 65, "CDS only: got ". scalar(@pairs) );
+is ( scalar(@pairs), 62, "CDS only: got ". scalar(@pairs) );
 
 
 # next test - include 3prime utr
@@ -42,7 +42,7 @@ foreach my $feat (@feats) {
 ok( $sirna->include_3pr(1) ) ;
 @pairs = $sirna->design;
 print "With 3p UTR: got ",scalar(@pairs),"\n" if $DEBUG;
-is( scalar(@pairs), 140 );
+is( scalar(@pairs), 124 );
 
 
 #third test - naked sequence
@@ -52,4 +52,4 @@ isa_ok($newseq, 'Bio::Seq') ;
 ok( $sirna->target($newseq) );
 @pairs = $sirna->design;
 print "Bare sequence: got ",scalar(@pairs),"\n" if $DEBUG;
-is ( scalar(@pairs),  142 ) ;
+is ( scalar(@pairs),  126 ) ;


### PR DESCRIPTION
In Perl 5.24.0, when running t/Tools/SiRNA.t, we were getting the warning
above on two consecutive lines.  This patch silences those warnings and
prevents the module from failing on future versions of perl.