### PR TITLE
Fixes remote taxonomy tests

### DIFF
--- a/t/RemoteDB/Taxonomy.t
+++ b/t/RemoteDB/Taxonomy.t
@@ -176,8 +176,16 @@ for my $db ($db_entrez, $db_flatfile) {
 
         @ids = $db->get_taxonids('Rhodotorula');
         cmp_ok @ids, '>=' , 2;
-        ok grep { $_ == 592558; } @ids;
-        ok grep { $_ == 5533; } @ids;
+        if ($db eq $db_entrez) {
+            ok grep { $_ == 592558 } @ids;
+            ok grep { $_ == 5533 } @ids;
+        } else {
+            # note the locally cached flatfile is out-of-date, but technically
+            # correct for testing purposes
+            diag(join(",", @ids));
+            ok grep { $_ == 266791 } @ids;
+            ok grep { $_ == 5533 } @ids;
+        }
     }
 }
 

--- a/t/RemoteDB/Taxonomy.t
+++ b/t/RemoteDB/Taxonomy.t
@@ -175,10 +175,9 @@ for my $db ($db_entrez, $db_flatfile) {
         $db eq $db_entrez ? is($id, undef) : is($id, 32061);
 
         @ids = $db->get_taxonids('Rhodotorula');
-        cmp_ok @ids, '>=' , 8;
-        @ids = $db->get_taxonids('Rhodotorula <Microbotryomycetidae>');
-        is @ids, 1;
-        is $ids[0], 231509;
+        cmp_ok @ids, '>=' , 2;
+        ok grep { $_ == 592558; } @ids;
+        ok grep { $_ == 5533; } @ids;
     }
 }
 


### PR DESCRIPTION
The NCBI taxonomy changed, and thus the query results expected in some of the tests here would no longer match. Part of addressing #160.