### PR TITLE
Adds support for automatic rebuild of Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ script:
     #- PERL5OPT=-MDevel::Cover=+ignore,prove,-coverage,statement,subroutine prove -lr t #limited version coverage test
     #- cover -report coveralls
 
+after_success:
+    - ./travis_scripts/trigger-dockerhub.sh
+
 #TODO - send emails to bioperl-guts-l
 notifications:
   email: 

--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -8,9 +8,9 @@ dockerapi="https://registry.hub.docker.com/u/bioperl/bioperl/trigger"
 ## Travis runs a build for several versions of Perl, but we want to
 ## trigger only for the same version of Perl as is running in the
 ## Docker container
-docker_perl="5.018"
+docker_perl="5.18"
 
-if [[ ${TRAVIS_PERL_VERSION:0:5} != "$docker_perl" ]] ; then
+if [[ ${TRAVIS_PERL_VERSION:0:4} != "$docker_perl" ]] ; then
     echo "Triggering Docker Hub only for Perl $docker_perl, not $TRAVIS_PERL_VERSION"
     exit 0
 fi

--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+# the Docker Hub API endpoint
+dockerapi="https://registry.hub.docker.com/u/bioperl/bioperl/trigger"
+
+## Travis runs a build for several versions of Perl, but we want to
+## trigger only for the same version of Perl as is running in the
+## Docker container
+docker_perl="5.018"
+
+if [[ ${TRAVIS_PERL_VERSION:0:5} != "$docker_perl" ]] ; then
+    echo "Triggering Docker Hub only for Perl $docker_perl, not $TRAVIS_PERL_VERSION"
+    exit 0
+fi
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] ; then
+    echo "Not triggering Docker Hub for pull requests."
+    exit 0
+fi
+
+if [[ -z "$DOCKERHUB_TOKEN" ]] ; then
+    echo "No API token for Docker Hub, add to repository settings."
+    exit 1
+fi
+
+## Should check for tag names that indicate release candidates rather
+## than release names, and then skip those.
+
+if [[ -n "$TRAVIS_TAG" && "$TRAVIS_TAG" != "false" ]] ; then
+    echo "Triggering rebuild of Docker image bioperl/bioperl:stable"
+    curl -H "Content-Type: application/json" \
+         --data '{"docker_tag": "stable"}' \
+         -X POST $dockerapi/$DOCKERHUB_TOKEN/
+else
+    echo "Triggering rebuild of Docker image bioperl/bioperl:latest"
+    curl -H "Content-Type: application/json" \
+         --data '{"docker_tag": "latest"}' \
+         -X POST $dockerapi/$DOCKERHUB_TOKEN/
+fi


### PR DESCRIPTION
This introduces the mechanism to use the Docker Hub API to trigger automatic rebuilds of the [bioperl/bioperl](https://hub.docker.com/r/bioperl/bioperl/) images. Tag `latest` is triggered if the build is for `master` (identified as not a pull request and not a tag), and only for the Perl version also used on the Docker image.