### PR TITLE
Includes tags patterned after release in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ notifications:
 branches:
   only:
     - master
-
+    - /^release-[1-9]*-[0-9]*-[0-9]*$/


### PR DESCRIPTION
It seems that tags would be matched by the branch whitelist if added there, so let's try this here.