### PR TITLE
Limit Docker Hub trigger

### DIFF
--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -27,8 +27,11 @@ fi
 
 ## Should check for tag names that indicate release candidates rather
 ## than release names, and then skip those.
+## However, this is already taken care of by the regular expression
+## for whitelisting branches.
 
 if [[ -n "$TRAVIS_TAG" && "$TRAVIS_TAG" != "false" ]] ; then
+    # if we are building a whitelisted tag, we trigger the stable image
     echo "Triggering rebuild of Docker image bioperl/bioperl:stable"
     curl -H "Content-Type: application/json" \
          --data '{"docker_tag": "stable"}' \
@@ -38,6 +41,7 @@ elif [[ "$TRAVIS_BRANCH" != "master" ]] ; then
     # pattern, we skip that here, and only trigger on master
     echo "Not triggering Docker Hub for branches other than master"
 else
+    # not a pull request, not a tag, and the branch is master
     echo "Triggering rebuild of Docker image bioperl/bioperl:latest"
     curl -H "Content-Type: application/json" \
          --data '{"docker_tag": "latest"}' \

--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -33,6 +33,10 @@ if [[ -n "$TRAVIS_TAG" && "$TRAVIS_TAG" != "false" ]] ; then
     curl -H "Content-Type: application/json" \
          --data '{"docker_tag": "stable"}' \
          -X POST $dockerapi/$DOCKERHUB_TOKEN/
+elif [[ "$TRAVIS_BRANCH" != "master" ]] ; then
+    # if someone were to create a branch that matches the whitelisting
+    # pattern, we skip that here, and only trigger on master
+    echo "Not triggering Docker Hub for branches other than master"
 else
     echo "Triggering rebuild of Docker image bioperl/bioperl:latest"
     curl -H "Content-Type: application/json" \


### PR DESCRIPTION
Limits triggering the rebuild of Docker Hub `latest` image to the master branch. 

Also adds some comments to make it clearer what conditions are acted upon.