### PR TITLE
Ambiguous codons being returned as stop codons

### DIFF
--- a/Bio/Tools/CodonTable.pm
+++ b/Bio/Tools/CodonTable.pm
@@ -726,7 +726,31 @@ sub is_start_codon{
 =cut
 
 sub is_ter_codon{
-    shift->_codon_is( shift, \@TABLES, $TERMINATOR );
+   my ($self, $value) = @_;
+   my $id = $self->{'id'};
+
+   # We need to ensure U is mapped to T (ie. UAG)
+   $value = uc $value;
+   $value =~ tr/U/T/;
+
+   if (length $value != 3  )  {
+       # Incomplete codons are not stop codons
+       return 0;
+   } else {
+       my $result = 0;
+
+       # For all the possible codons, if any are not a stop
+       # codon, fail immediately
+       for my $c ( $self->unambiguous_codons($value) ) {
+	   my $m = substr( $TABLES[$id], $CODONS->{$c}, 1 );
+	   if($m eq $TERMINATOR) {
+	       $result = 1;
+	   } else {
+	       return 0;
+	   }
+       }
+       return $result;
+   }
 }
 
 # desc: compares the passed value with a single entry in the given

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -160,16 +160,21 @@ ok $test;
 # boolean tests
 $myCodonTable->id(1); # Standard table
 
-ok $myCodonTable->is_start_codon('ATG');
-is $myCodonTable->is_start_codon('GGH'), 0;
-ok $myCodonTable->is_start_codon('HTG');
-is $myCodonTable->is_start_codon('CCC'), 0;
+ok $myCodonTable->is_start_codon('ATG'), 'is_start_codon, ATG';
+is $myCodonTable->is_start_codon('GGH'), 0, 'is_start_codon, GGH';
+ok $myCodonTable->is_start_codon('HTG'), 'is_start_codon, HTG';
+is $myCodonTable->is_start_codon('CCC'), 0, 'is_start_codon, CCC';
 
-ok $myCodonTable->is_ter_codon('UAG');
-ok $myCodonTable->is_ter_codon('TaG');
-ok $myCodonTable->is_ter_codon('TaR');
-ok $myCodonTable->is_ter_codon('tRa');
-is $myCodonTable->is_ter_codon('ttA'), 0;
+ok $myCodonTable->is_ter_codon('UAG'), 'is_ter_codon, U should map to T, UAG';
+ok $myCodonTable->is_ter_codon('TaG'), 'is_ter_codon,TaG';
+ok $myCodonTable->is_ter_codon('TaR'), 'is_ter_codon,TaR';
+ok $myCodonTable->is_ter_codon('tRa'), 'is_ter_codon,tRa';
+is $myCodonTable->is_ter_codon('ttA'), 0, 'is_ter_codon,ttA';
+
+# Ambiguous codons should fail
+is $myCodonTable->is_ter_codon('NNN'), 0, 'is_ter_codon, ambiguous codons should fail, NNN';
+is $myCodonTable->is_ter_codon('TAN'), 0, 'is_ter_codon, ambiguous codons should fail, TAN';
+is $myCodonTable->is_ter_codon('CC'), 0, 'is_ter_codon, incomplete codons should fail, CC';
 
 ok $myCodonTable->is_unknown_codon('jAG');
 ok $myCodonTable->is_unknown_codon('jg');

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -7,7 +7,7 @@ BEGIN {
     use lib '.';
     use Bio::Root::Test;
 
-    test_begin(-tests => 81);
+    test_begin(-tests => 84);
 
     use_ok('Bio::Tools::CodonTable');
     use_ok('Bio::CodonUsage::IO');


### PR DESCRIPTION
- is_ter_codon was incorrectly returning ambiguous codons as stop codons (ie. NNN was being returned true), any failure in the list of unambiguous codons should return false, the opposite was occuring
- U was not being remapped to T, it's needed for UAG and such
- Added tests for better coverage of corner cases