### PR TITLE
Support FTS5 in Bio::DB::SeqFeature::Store::DBI::SQLite

### DIFF
--- a/Bio/DB/SeqFeature/Store/DBI/SQLite.pm
+++ b/Bio/DB/SeqFeature/Store/DBI/SQLite.pm
@@ -436,7 +436,7 @@ sub _create_attribute_fts{
         $dbh->do("CREATE VIRTUAL TABLE "
              . $self->_attribute_table
              . " USING " . $fts_versions[-1]
-             . "(id integer not null, attribute_id integer not null, attribute_value text)");
+             . "(id, attribute_id, attribute_value)");
     }
 }
 


### PR DESCRIPTION
When FTS is specified, Bio::DB::SeqFeature::Store::DBI::SQLite attempts to use the newest supported FTS. DBD::SQLite has supported FTS5 since 1.51_01; however, the CREATE VIRTUAL TABLE statement results in an error like the following:

> DBD::SQLite::db do failed: parse error in "id integer not null" at /usr/local/lib/perl5/site_perl/Bio/DB/SeqFeature/Store/DBI/SQLite.pm line 436.

This code previously worked in [FTS3/FTS4](https://www.sqlite.org/fts3.html), where column types were optional in the CREATE VIRTUAL TABLE statement:

> If column names are explicitly provided for the FTS table as part of the CREATE VIRTUAL TABLE statement, then a datatype name may be optionally specified for each column. This is pure syntactic sugar, the supplied typenames are not used by FTS or the SQLite core for any purpose. The same applies to any constraints specified along with an FTS column name - they are parsed but not used or recorded by the system in any way.

However, neither column types, nor constraints are permitted in FTS5:

> It is an error to add types, constraints or PRIMARY KEY declarations to a CREATE VIRTUAL TABLE statement used to create an FTS5 table.

This patch removes the column types and constraints, and restores compatibility with FTS5.

