### PR TITLE
Fix test RemoteDB/Taxonomy.t: requires networking

### DIFF
--- a/t/RemoteDB/Taxonomy.t
+++ b/t/RemoteDB/Taxonomy.t
@@ -487,16 +487,17 @@ SKIP: {
         # 'Phygadeuon ovatus'    | "No hit"      | 666060
         # 'Trimorus ovatus'      | "No hit"      | 666060
 
-        my @ids = $db_entrez->get_taxonids('Lissotriton vulgaris');
+        my @ids;
+        @ids = $db->get_taxonids('Lissotriton vulgaris');
         is $ids[0], 8324, 'Correct: Lissotriton vulgaris';
-        my @ids = $db_entrez->get_taxonids('Chlorella vulgaris');
+        @ids = $db->get_taxonids('Chlorella vulgaris');
         is $ids[0], 3077, 'Correct: Chlorella vulgaris';
-        my @ids = $db_entrez->get_taxonids('Phygadeuon solidus');
+        @ids = $db->get_taxonids('Phygadeuon solidus');
         is $ids[0], 1763951, 'Correct: Phygadeuon solidus';
-        my @ids = $db_entrez->get_taxonids('Ovatus');
+        @ids = $db->get_taxonids('Ovatus');
         is $ids[0], 666060, 'Correct: Ovatus';
-        my @ids = $db_entrez->get_taxonids('Phygadeuon ovatus');
+        @ids = $db->get_taxonids('Phygadeuon ovatus');
         is $ids[0], 'No hit', 'Correct: No hit';
-        my @ids = $db_entrez->get_taxonids('Trimorus ovatus');
+        @ids = $db->get_taxonids('Trimorus ovatus');
         is $ids[0], 'No hit', 'Correct: No hit';
 }

--- a/t/RemoteDB/Taxonomy.t
+++ b/t/RemoteDB/Taxonomy.t
@@ -474,7 +474,7 @@ SKIP: {
 
 # tests for #212
 SKIP: {
-        test_skip( -tests => 12, -requires_networking => 0 );
+        test_skip( -tests => 12, -requires_networking => 1 );
 
         my $db = Bio::DB::Taxonomy->new( -source => "entrez" );
 


### PR DESCRIPTION
The test requires the network and was failing on a Travis CI build that I ran on my account [here](https://travis-ci.org/zmughal/bioperl-live/jobs/221986832#L2535) and on this repository [here](https://travis-ci.org/bioperl/bioperl-live/jobs/221991748#L2546).

I also made some fixes so that variables are only declared once.