### PR TITLE
Use a Travis cron job for network tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
       - libxml2-dev
 
 before_install:
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
   - build-perl
@@ -44,6 +45,10 @@ before_install:
   - cpanm DBD::mysql DBD::Pg DBD::SQLite 2>&1 | tail -n 1
   - cpanm Test::Pod 2>&1 | tail -n 1
   - cpanm Bio::ASN1::EntrezGene 2>&1 | tail -n 1
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" -a "$BRANCH" = "network-cron-master" ]; then
+      export BIOPERL_NETWORK_TESTING=1;
+      git fetch origin master:master; git checkout master;
+    fi
   - if [ "$BIOPERL_NETWORK_TESTING" = "1" ]; then
       export TRAVIS_AUTHOR_TESTING=1;
       export TRAVIS_RELEASE_TESTING=1;
@@ -78,3 +83,4 @@ branches:
   only:
     - master
     - /^release-[1-9]*-[0-9]*-[0-9]*$/
+    - network-cron-master


### PR DESCRIPTION
This is a PR of what was discussed on the mailing list and in <https://github.com/bioperl/bioperl-live/issues/224>. In order to activate the changes, the cron job feature must be activated as follows under [Travis CI settings for bioperl-live](https://travis-ci.org/bioperl/bioperl-live/settings):

![selection_676](https://cloud.githubusercontent.com/assets/94489/26267149/3996963e-3cae-11e7-8652-743021bbfa7d.png)

after creating a branch called `network-cron-master`.

I have been running the network tests [on my own fork of the repo and it has been failing](https://travis-ci.org/zmughal/bioperl-live/builds), so they can be used to identify areas that can be worked on.

![selection_675](https://cloud.githubusercontent.com/assets/94489/26267208/7b5b5e42-3cae-11e7-83a3-cea4c459e687.png)
