### PR TITLE
TravisCI: cache Perl dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,8 @@ before_install:
   - build-dist
   - cd $BUILD_DIR
 install:
-  - cpan-install --deps
-  - cpan-install --coverage
+  - cpan-install --update-prereqs --deps
+  - cpan-install --update-prereqs --coverage
 before_script:
   - coverage-setup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: perl
+cache:
+  directories:
+    # local::lib caching
+    - $HOME/perl5
+
 perl:
   - "5.26"
   - "5.24"


### PR DESCRIPTION
This makes the builds run faster and use fewer resources.

See <https://github.com/bioperl/bioperl-live/issues/242>.