### PR TITLE
Fixes test for running code coverage

### DIFF
--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -25,7 +25,7 @@ if [[ -z "$DOCKERHUB_TOKEN" ]] ; then
     exit 1
 fi
 
-if [[ -n "$COVERAGE" && $COVERAGE -ne 0 ]] ; then
+if [[ -n "$COVERAGE" && "$COVERAGE" != "0" ]] ; then
     echo "Not triggering Docker Hub for code coverage build."
     exit 0
 fi

--- a/travis_scripts/trigger-dockerhub.sh
+++ b/travis_scripts/trigger-dockerhub.sh
@@ -25,7 +25,7 @@ if [[ -z "$DOCKERHUB_TOKEN" ]] ; then
     exit 1
 fi
 
-if [[ -n "$COVERAGE" ]] ; then
+if [[ -n "$COVERAGE" && $COVERAGE -ne 0 ]] ; then
     echo "Not triggering Docker Hub for code coverage build."
     exit 0
 fi


### PR DESCRIPTION
Apparently COVERAGE gets set (to a non-empty value) even if not defined as `COVERAGE=1` in the build environment.

I don't know where the underlying script (`coverage-setup`) is to verify, but I hope it doesn't get set to something other than `0`. @zmughal can you check?