### PR TITLE
Omit unnecessary parent_id attribute added by GFF3Loader

### DIFF
--- a/Bio/DB/SeqFeature/Store/GFF3Loader.pm
+++ b/Bio/DB/SeqFeature/Store/GFF3Loader.pm
@@ -555,7 +555,6 @@ sub handle_feature { #overridden
   $feature_id = '' unless defined $feature_id;
   $name       = '' unless defined $name;  # prevent uninit variable warnings
   # push @{$unreserved->{Alias}},$feature_id  if $has_loadid && $feature_id ne $name;
-  $unreserved->{parent_id} = \@parent_ids   if @parent_ids;
 
   # POSSIBLY A PERMANENT HACK -- TARGETS BECOME ALIASES
   # THIS IS TO ALLOW FOR TARGET-BASED LOOKUPS

--- a/Bio/DB/SeqFeature/Store/GFF3Loader.pm
+++ b/Bio/DB/SeqFeature/Store/GFF3Loader.pm
@@ -556,6 +556,7 @@ sub handle_feature { #overridden
   $feature_id = '' unless defined $feature_id;
   $name       = '' unless defined $name;  # prevent uninit variable warnings
   # push @{$unreserved->{Alias}},$feature_id  if $has_loadid && $feature_id ne $name;
+  # If DEBUG != 0, any Parent attribute is also copied over (as 'parent_id')
   $unreserved->{parent_id} = \@parent_ids   if DEBUG && @parent_ids;
 
   # POSSIBLY A PERMANENT HACK -- TARGETS BECOME ALIASES

--- a/Bio/DB/SeqFeature/Store/GFF3Loader.pm
+++ b/Bio/DB/SeqFeature/Store/GFF3Loader.pm
@@ -70,6 +70,7 @@ use strict;
 use Carp 'croak';
 use Bio::DB::GFF::Util::Rearrange;
 use Bio::DB::SeqFeature::Store::LoadHelper;
+use constant DEBUG => 0;
 
 use base 'Bio::DB::SeqFeature::Store::Loader';
 
@@ -555,6 +556,7 @@ sub handle_feature { #overridden
   $feature_id = '' unless defined $feature_id;
   $name       = '' unless defined $name;  # prevent uninit variable warnings
   # push @{$unreserved->{Alias}},$feature_id  if $has_loadid && $feature_id ne $name;
+  $unreserved->{parent_id} = \@parent_ids   if DEBUG && @parent_ids;
 
   # POSSIBLY A PERMANENT HACK -- TARGETS BECOME ALIASES
   # THIS IS TO ALLOW FOR TARGET-BASED LOOKUPS


### PR DESCRIPTION
Bio::DB::SeqFeature::Store::GFF3Loader adds the undocumented attribute _parent_id_ to the resulting Bio::DB::SeqFeature::Store database. This attribute, which is not referenced anywhere else in the code, is added in a section of code labeled "TEMPORARY HACKS TO SIMPLIFY DEBUGGING". 

Since this attribute can take up non-trivial space in the attribute table, depending on the GFF (e.g., I just checked a gene model GFF from NCBI that was run through GFF3Loader via bp_seqfeature_load.pl, and there were 83,590 parent_id rows in the attribute table---and these are indexed as well), it could provide modest space savings & search performance improvements to omit the parent_id attribute (or comment-out for posterity, or set only if a DEBUG constant is set).

On a related note, I tend to manually remove the load_id attribute added by GFF3Loader as well, though this one as at least accessible via Bio::DB::SeqFeature::load_id (whose documentation contains the comment "This method may not be supported in future versions of the module").