### PR TITLE
Change `or` to `||` to fix precedence warning

### DIFF
--- a/Bio/DB/IndexedBase.pm
+++ b/Bio/DB/IndexedBase.pm
@@ -842,7 +842,7 @@ sub _fh {
     my $file = $self->file($id) or return;
     return eval {
       $self->_fhcache( File::Spec->catfile($self->{dirname}, $file));
-    } or $self->throw( "Can't open file $file" );
+    } || $self->throw( "Can't open file $file" );
 }
 
 


### PR DESCRIPTION
Fixes <https://github.com/bioperl/bioperl-live/issues/250>.

See [this build log for perl 5.24](https://travis-ci.org/zmughal/bioperl-live/jobs/274671546)
to confirm.
