### PR TITLE
fixed bootstrapping bug where no bootstrap could have been 100 percent

### DIFF
--- a/lib/Bio/Tree/Statistics.pm
+++ b/lib/Bio/Tree/Statistics.pm
@@ -106,6 +106,14 @@ sub assess_bootstrap{
    my ($self,$bs_trees,$guide_tree) = @_;
    my @consensus;
 
+   if(!defined($bs_trees) || ref($bs_trees) ne 'ARRAY'){
+     die "ERROR: second parameter in assess_bootstrap() must be a list";
+   }
+   my $num_bs_trees = scalar(@$bs_trees);
+   if($num_bs_trees < 1){
+     die "ERROR: no bootstrap trees were passed to assess_bootstrap()";
+   }
+
    # internal nodes are defined by their children
 
    my (%lookup,%internal);
@@ -129,11 +137,11 @@ sub assess_bootstrap{
        }
        $i++;
    }
-   my @save;
+   #my @save; # unsure why this variable is needed
    for my $l ( keys %lookup ) {
        if( defined $internal{$l} ) {#&& $lookup{$l} > $min_seen ) {
            my $intnode = $guide_tree->find_node(-internal_id => $internal{$l});
-           $intnode->bootstrap(sprintf("%d",100 * $lookup{$l} / $i));
+           $intnode->bootstrap(sprintf("%d",100 * $lookup{$l} / $num_bs_trees));
        }
    }
    return $guide_tree;

--- a/t/Tree/TreeStatistics.t
+++ b/t/Tree/TreeStatistics.t
@@ -6,7 +6,7 @@ use strict;
 BEGIN { 
     use Bio::Root::Test;
     
-    test_begin(-tests => 42);
+    test_begin(-tests => 43);
 
     use_ok('Bio::TreeIO');
     use_ok('Bio::Tree::Statistics');
@@ -23,6 +23,16 @@ my $node = $tree->find_node(-id => 'N14');
 my $stats = Bio::Tree::Statistics->new();
 is $stats->cherries($tree), 8, 'cherries';
 is $stats->cherries($tree, $node), 4, 'cherries';
+
+subtest 'bootstrapping' => sub{
+  plan tests=>15;
+  my @bs_trees = ($tree) x 10;
+  my $bs_tree  = $stats->assess_bootstrap(\@bs_trees, $tree);
+  for my $node ($bs_tree->get_nodes){
+    next if($node->is_Leaf);
+    is $node->bootstrap, 100, "Testing bootstrap for node"
+  }
+};
 
 # traits
 my $key = $tree->add_trait(test_input_file('traits.tab'), 4);
@@ -136,5 +146,4 @@ $node = $tree->find_node(-id => 'N10');
 $mc = $stats->mc($tree, $key, $node);
 is ($mc->{blue}, 2, 'monophyletic clade size');
 is ($mc->{red}, 2, 'monophyletic clade size');
-
 


### PR DESCRIPTION
I found that in `assess_bootstrap()`, that the denominator in the bootstrap calculation had an off-by-one error.

Also: I added a very simple test for `assess_bootstrap()` in `t/Tree/TreeStatistics.t`.