### PR TITLE
replacing all calls to Bio::DB::IndexedBase::_strip_crnl with native perl tr operator

### DIFF
--- a/lib/Bio/DB/Fasta.pm
+++ b/lib/Bio/DB/Fasta.pm
@@ -292,7 +292,7 @@ sub subseq {
     seek($fh, $filestart,0);
     read($fh, $data, $filestop-$filestart+1);
 
-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
+    $data =~ tr/\n\r//d; #strip control characters
 
     if ($strand == -1) {
         # Reverse-complement the sequence
@@ -334,7 +334,7 @@ sub header {
     read($fh, $data, $headerlen);
     # On Windows chomp remove '\n' but leaves '\r'
     # when reading '\r\n' in binary mode
-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
+    $data =~ tr/\n\r//d; #strip control characters
     substr($data, 0, 1) = '';
     return $data;
 }

--- a/lib/Bio/DB/IndexedBase.pm
+++ b/lib/Bio/DB/IndexedBase.pm
@@ -243,42 +243,6 @@ package Bio::DB::IndexedBase;
 BEGIN {
     @AnyDBM_File::ISA = qw(DB_File GDBM_File NDBM_File SDBM_File)
         if(!$INC{'AnyDBM_File.pm'});
-    # Remove carriage returns (\r) and newlines (\n) from a string.  When
-    # called from subseq, this can take a signficiant portion of time, in
-    # Variant Effect Prediction. Therefore we compile the match portion.
-
-    eval 'require Inline::C';
-    if ( $INC{'Inline/C.pm'} ) {
-        # C can do _strip_crnl much faster. But this requires the
-        # Inline::C module which we don't require people to have. So we make
-        # this optional by wrapping the C code in an eval. If the eval works,
-        # the Perl strip_crnl() function is overwritten.
-        Inline->bind(
-            C => q(
-        /*
-        Strip all newlines (\n) and carriage returns (\r) from the string
-        */
-        char* _strip_crnl(char* str) {
-          char *s;
-          char *s2 = str;
-          for (s = str; *s; *s++) {
-            if (*s != '\n' && *s != '\r') {
-              *s2++ = *s;
-            }
-          }
-          *s2 = '\0';
-          return str;
-        }
-        )
-        );
-    } else {
-        # "tr" is much faster than the regex, with "s"
-        *Bio::DB::IndexedBase::_strip_crnl = sub {
-            my $str = shift;
-            $str =~ tr/\n\r//d;
-            return $str;
-        };
-    }
 }
 
 use strict;

--- a/lib/Bio/DB/Qual.pm
+++ b/lib/Bio/DB/Qual.pm
@@ -335,7 +335,7 @@ sub subqual {
     read($fh, $data, $filestop-$filestart+1);
 
     # Process quality score
-    Bio::DB::IndexedBase::_strip_crnl($data);
+    $data =~ tr/\n\r//d; #strip control characters
     my $subqual = 0;
     $subqual = 1 if ( $start || $stop );
     my @data;
@@ -379,8 +379,7 @@ sub header {
     read($fh, $data, $headerlen);
     # On Windows chomp remove '\n' but leaves '\r'
     # when reading '\r\n' in binary mode,
-    # _strip_crnl removes both
-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
+    $data =~ tr/\n\r//d; #strip control characters
     substr($data, 0, 1) = '';
     return $data;
 }


### PR DESCRIPTION
Bio::DB::IndexedBase::_strip_crnl calls Inline::C in an eval statement and does runtime compilation of a C function. The eval statement sometimes does not work and can generate other issues with modules that call Inline::C internally. The C based method for the perl code was apparently done for performance reasons, but perl's native tr (translator) operator gives similar performance without the weird C compilation baggage associated with Inline::C. Also using the operator directly rather than calling _strip_crnl as a function avoids copying the string with each function call.

I have both removed the function _strip_crnl and replaced all locations where it is used with translator operations.