### PR TITLE
Fix Codon Table 0 (strict) that was not selectable

### DIFF
--- a/lib/Bio/Tools/CodonTable.pm
+++ b/lib/Bio/Tools/CodonTable.pm
@@ -329,7 +329,7 @@ sub new {
                  )],
              @args);
 
-    $id = 1 if ( ! $id );
+    $id = 1 if ( ! defined ( $id ) );
     $id  && $self->id($id);
     return $self; # success - we hope!
 }


### PR DESCRIPTION
[BUG] Table 0 (strict) was shifted in table 1, because when `$id` has value `0`  the following test is false `$id = 1 if (  $id ) );`.  Fixed by changing if statement which now accepts  `0` as value;