### PR TITLE
Reduce the number of indirect object calls

### DIFF
--- a/t/SearchIO/Tiling.t
+++ b/t/SearchIO/Tiling.t
@@ -148,9 +148,10 @@ my %example_files = (
                )]
     );
 
-ok( $blio = new Bio::SearchIO( 
-	-file=>test_input_file('dcr1_sp.WUBLASTP'),
-	-format=>'blast'), 'parse data file');
+ok( $blio = Bio::SearchIO->new(
+	-file => test_input_file('dcr1_sp.WUBLASTP'),
+	-format => 'blast',
+    ), 'parse data file');
 
 $result = $blio->next_result;
 while ( $_ = $result->next_hit ) {

--- a/t/SeqIO/fasta.t
+++ b/t/SeqIO/fasta.t
@@ -90,11 +90,11 @@ SKIP: {
     my @datain = <$FILE>;
     close $FILE;
 
-    my $in = new IO::String(join('', @datain));
-    my $seqin = new Bio::SeqIO( -fh => $in,
+    my $in = IO::String->new(join('', @datain));
+    my $seqin = Bio::SeqIO->new( -fh => $in,
                 -format => $type);
-    my $out = new IO::String;
-    my $seqout = new Bio::SeqIO( -fh => $out,
+    my $out = IO::String->new;
+    my $seqout = Bio::SeqIO->new( -fh => $out,
                  -format => $type);
     my $seq;
     while( defined($seq = $seqin->next_seq) ) {

--- a/t/SeqIO/gcg.t
+++ b/t/SeqIO/gcg.t
@@ -83,11 +83,11 @@ SKIP: {
     my @datain = <$FILE>;
     close $FILE;
 
-    my $in = new IO::String(join('', @datain));
-    my $seqin = new Bio::SeqIO( -fh => $in,
+    my $in = IO::String->new(join('', @datain));
+    my $seqin = Bio::SeqIO->new( -fh => $in,
                 -format => $type);
-    my $out = new IO::String;
-    my $seqout = new Bio::SeqIO( -fh => $out,
+    my $out = IO::String->new;
+    my $seqout = Bio::SeqIO->new( -fh => $out,
                  -format => $type);
     my $seq;
     while( defined($seq = $seqin->next_seq) ) {	


### PR DESCRIPTION
There are some indirect object calls, e.g. `new Bio::SearchIO(...)` which do not conform to modern coding standards and can be ambiguous. This PR removes them.

Unfortunately, `catch` and `throw` in the `Error` module still use this notation in `t/Root/Exception.t`.

## References

#307 