### PR TITLE
Adjust Swiss-Prot FT A..B lines

### DIFF
--- a/lib/Bio/SeqIO/swiss.pm
+++ b/lib/Bio/SeqIO/swiss.pm
@@ -1289,7 +1289,7 @@ sub _read_FTHelper_swissprot {
         $desc,                  # The descriptive text
         $ftid,                  # feature Id is like a qualifier but there can be only one of them
        );
-    if ( m/^FT\s{3}(\w+)\s+([\d\?\<]+)\s+([\d\?\>]+)\s*(.*)$/ox) {
+    if ( m/^FT\s{3}(\w+)\s+([\d\?\<]+)[\s.]+([\d\?\>]+)\s*(.*)$/ox) {
         $key = $1;
         my $loc1 = $2;
         my $loc2 = $3;
@@ -1300,9 +1300,20 @@ sub _read_FTHelper_swissprot {
         } else {
             $desc = "";
         }
+    } elsif ( m/^FT\s{3}(\w+)\s+([\d\?\<]+)\s+(.*)$/ox) {
+        $key = $1;
+        my $loc1 = $2;
+        my $loc2 = $2;
+        $loc = "$loc1";
+        if ($3 && (length($3) > 0)) {
+            $desc = $3;
+            chomp($desc);
+        } else {
+            $desc = "";
+        }
     }
 
-    while ( defined($_ = $self->_readline) && /^FT\s{20,}(\S.*)$/ ) {
+    while ( defined($_ = $self->_readline) && /^FT\s{4,}(\S.*)$/ ) {
         my $continuation_line = $1;
         if ( $continuation_line =~ /.FTId=(.*)\./ ) {
             $ftid=$1;


### PR DESCRIPTION
UniProt FT lines may have two dots connecting the positions intstead of the historic blanks. This commits allows for either format. Also new, an FT line addressing only a single residue may now be addressing this single position only.

No addressed are the specification of splice variants together with a feature, as in 
```
FT   CONFLICT        P78310-2:343
```
or
```
FT   CARBOHYD        P15151-2:360
```
or
```
FT   INIT_MET        P08195-2:1
FT   MOD_RES         P08195-2:2
```
or 
```
FT   VARIANT         Q02297-10:127
```

An initial report on this problem was erroneously posted on https://github.com/bioperl/Bio-DB-SwissProt/issues/4 .

Thanks!

Steffen
