### PR TITLE
fix for writing large_fasta sequences

### DIFF
--- a/lib/Bio/SeqIO/fasta.pm
+++ b/lib/Bio/SeqIO/fasta.pm
@@ -314,7 +314,7 @@ sub write_seq {
             my $buff_max = 2000;
             my $buff_size = int($buff_max/$width)*$width; #< buffer is even multiple of widths
             my $seq_length = $seq->length;
-            my $num_chunks = int($seq_length/$buff_size+1);
+            my $num_chunks = int(($seq_length-1)/$buff_size+1);
             for( my $c = 0; $c < $num_chunks; $c++ ) {
                 my $buff_end = $buff_size*($c+1);
                 $buff_end = $seq_length if $buff_end > $seq_length;

--- a/lib/Bio/SeqIO/fasta.pm
+++ b/lib/Bio/SeqIO/fasta.pm
@@ -311,7 +311,7 @@ sub write_seq {
             # for large seqs, don't call seq(), it defeats the
             # purpose of the largeseq functionality.  instead get
             # chunks of the seq, $width at a time
-            my $buff_max = 2000;
+            my $buff_max = 200000;
             my $buff_size = int($buff_max/$width)*$width; #< buffer is even multiple of widths
             my $seq_length = $seq->length;
             my $num_chunks = int(($seq_length-1)/$buff_size+1);


### PR DESCRIPTION
* the window count was off for cases where the sequence length aligned with the window size
* i also bumped up the max buffer size