### PR TITLE
Add initial GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,15 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         perl: ['5']
+        author-testing: [false]
         include:
+          - { os: 'ubuntu-latest', perl: "5"    , author-testing: true  }
           - { os: 'ubuntu-latest', perl: "5.16" }
           - { os: 'ubuntu-latest', perl: "5.20" }
           - { os: 'ubuntu-latest', perl: "5.30" }
           - { os: 'ubuntu-latest', perl: "5.32" }
           - { os: 'ubuntu-latest', perl: "5.36" }
-    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}, author (${{ matrix.author-testing || 'false' }})
 
     steps:
       - name: Get dist artifact
@@ -90,6 +92,17 @@ jobs:
       - name: Install Perl deps
         run: |
           cpanm --notest --installdeps .
+
+      - name: Install Perl develop deps
+        if: matrix.author-testing
+        run: |
+          cpanm --notest --installdeps --with-develop .
+
+      - name: Set AUTHOR_TESTING
+        if: matrix.author-testing
+        shell: bash
+        run: |
+          echo "AUTHOR_TESTING=1" >> $GITHUB_ENV
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,13 @@ jobs:
         perl: ['5']
         author-testing: [false]
         include:
-          - { os: 'ubuntu-latest', perl: "5"    , author-testing: true  }
+          - { os: 'ubuntu-latest', perl: "5"    , author-testing: true  , coverage: true }
           - { os: 'ubuntu-latest', perl: "5.16" }
           - { os: 'ubuntu-latest', perl: "5.20" }
           - { os: 'ubuntu-latest', perl: "5.30" }
           - { os: 'ubuntu-latest', perl: "5.32" }
           - { os: 'ubuntu-latest', perl: "5.36" }
-    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}, author (${{ matrix.author-testing || 'false' }})
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}, author (${{ matrix.author-testing || 'false' }}), coverage (${{ matrix.coverage }})
 
     steps:
       - name: Get dist artifact
@@ -98,12 +98,27 @@ jobs:
         run: |
           cpanm --notest --installdeps --with-develop .
 
+      - name: Install Perl coverage deps
+        if: matrix.coverage
+        run: |
+          cpanm --notest Devel::Cover::Report::Coveralls
+
       - name: Set AUTHOR_TESTING
         if: matrix.author-testing
         shell: bash
         run: |
           echo "AUTHOR_TESTING=1" >> $GITHUB_ENV
 
-      - name: Run tests
+      - name: Run tests (no coverage)
+        if: ${{ ! matrix.coverage }}
         run: |
           cpanm --verbose --test-only .
+
+      - name: Run tests (with coverage)
+        if: matrix.coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HARNESS_PERL_SWITCHES: -MDevel::Cover
+        run: |
+          cpanm --verbose --test-only .
+          cover -report Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+env:
+  PKG_DEPS_UBUNTU: >-
+    libdb-dev
+
+jobs:
+  dist:
+    name: Make distribution using Dist::Zilla
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Cache ~/perl5
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-dist-locallib
+          path: ~/perl5
+      - name: Perl version
+        run: |
+          perl -v
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install local::lib
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+      - name: Install Dist::Zilla
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm -n Dist::Zilla
+          dzil authordeps --missing | cpanm -n
+      - name: Make distribution
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          dzil build --in build-dir
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./build-dir
+  test:
+    needs: dist
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        perl: ['5']
+        include:
+          - { os: 'ubuntu-latest', perl: "5.16" }
+          - { os: 'ubuntu-latest', perl: "5.20" }
+          - { os: 'ubuntu-latest', perl: "5.30" }
+          - { os: 'ubuntu-latest', perl: "5.32" }
+          - { os: 'ubuntu-latest', perl: "5.36" }
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+
+      # Setup system deps
+      - name: Setup system deps (apt)
+        if: runner.os == 'Linux' && env.PKG_DEPS_UBUNTU
+        run: |
+          sudo apt-get -y update && sudo apt-get install -y --no-install-recommends ${{ env.PKG_DEPS_UBUNTU }}
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Set up perl (Strawberry)
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          distribution: 'strawberry'
+
+      - run: perl -V
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest --installdeps .
+
+      - name: Run tests
+        run: |
+          cpanm --verbose --test-only .


### PR DESCRIPTION
Since Travis CI is changed its terms, many FOSS projects on GitHub have started
using GitHub Actions instead. This was previously discussed at
<https://github.com/bioperl/bioperl-live/issues/224#issuecomment-1093038760>.

---

This PR is an initial working CI workflow to get started with GitHub Actions. <del>I
believe that further work can be done to enable Coveralls code coverage.</del>

<del>I can either add that in this PR or in subsequent PRs.</del>

<ins>I have added Coveralls support to this PR</ins>