### PR TITLE
Add minimum dependency on base.pm v2.18

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Summary of important user-visible changes for BioPerl
 -----------------------------------------------------
 
 {{$NEXT}}
+    * Add minimum dependency on base.pm v2.18. Fixes bug in some cases when
+      using SUPER::new() [#307].
 
 1.7.8     2021-02-02 23:02:18-06:00 America/Chicago
     * Bio::SeqIO::interpro has been moved to a separate repository to

--- a/lib/Bio/Root/Root.pm
+++ b/lib/Bio/Root/Root.pm
@@ -3,7 +3,7 @@ package Bio::Root::Root;
 use strict;
 use Bio::Root::IO;
 use Scalar::Util qw(blessed reftype);
-use base qw(Bio::Root::RootI);
+use base 2.18 qw(Bio::Root::RootI);
 
 =head1 NAME
 


### PR DESCRIPTION
This fixes a bug in some cases when using `SUPER::new()` such as:

```
t/SearchIO/Tiling.t .................
Error: Can't locate object method "new" via package "Bio::Search::HSP::GenericHSP::SUPER"
```

Fixes <https://github.com/bioperl/bioperl-live/issues/307>.

Connects with <https://github.com/bioperl/bioperl-live/pull/378>.
