### PR TITLE
Fix bsml_sax.t by using lax SAX parser

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Summary of important user-visible changes for BioPerl
 {{$NEXT}}
     * Add minimum dependency on base.pm v2.18. Fixes bug in some cases when
       using SUPER::new() [#307].
+    * Fix test for BSML SAX by using lax parser XML::SAX::PurePerl since
+      the external DTD URL now 404s [#376].
 
 1.7.8     2021-02-02 23:02:18-06:00 America/Chicago
     * Bio::SeqIO::interpro has been moved to a separate repository to

--- a/t/SeqIO/bsml_sax.t
+++ b/t/SeqIO/bsml_sax.t
@@ -9,6 +9,7 @@ BEGIN {
 	test_begin(-tests => 15,
 			   -requires_modules => [qw(XML::SAX
 									    XML::SAX::Writer
+									    XML::SAX::PurePerl
 										XML::SAX::Base)]);
     
 	use_ok('Bio::SeqIO');
@@ -16,6 +17,10 @@ BEGIN {
 
 my $verbose = test_debug();
 
+# Using lax parser XML::SAX::PurePerl due to external DTD error (404 for URL,
+# invalid redeclaration of predefined entity) instead of others such as
+# XML::LibXML::SAX. See GH#376.
+local $XML::SAX::ParserPackage = 'XML::SAX::PurePerl';
 my $str = Bio::SeqIO->new(-format => 'bsml_sax',
 			  -verbose => $verbose,
 			  -file => test_input_file('U83300.bsml'));


### PR DESCRIPTION
The test `t/SeqIO/bsml_sax.t` may fail on systems with older versions of
`XML::LibXML` due to a 404 for the external BSML DTD's URL. This gives
the error:

```
http error : Unknown IO error
t/SeqIO/bsml_sax.t ..................
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 14/15 subtests
```

Uses lax parser XML::SAX::PurePerl within the test which does not try to
fetch the external DTD.

Fixes <https://github.com/bioperl/bioperl-live/issues/376>.

Connects with <https://github.com/bioperl/bioperl-live/pull/379>.
