### PR TITLE
Fix tiny bug

### DIFF
--- a/lib/Bio/Tools/GFF.pm
+++ b/lib/Bio/Tools/GFF.pm
@@ -739,7 +739,7 @@ sub _gff1_string{
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
     }
-    $name = 'SEQ' if (! $name and $name ne "0");
+    $name = 'SEQ' if ! length($name);
 
     $str = join("\t",
                 $name,
@@ -805,7 +805,7 @@ sub _gff2_string{
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
     }
-    $name = 'SEQ' if (! $name and $name ne "0");
+    $name = 'SEQ' if ! length($name);
 
     $str1 = join("\t",
                  $name,
@@ -907,7 +907,7 @@ sub _gff25_string {
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
     } 
-    $name = 'SEQ' if (! $name and $name ne "0");
+    $name = 'SEQ' if ! length($name);
 
     $str1 = join("\t",
                  $name,
@@ -1011,7 +1011,7 @@ sub _gff3_string {
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
     } 
-    $name = 'SEQ' if (! $name and $name ne "0");
+    $name = 'SEQ' if ! length($name);
 
     my @groups;
 

--- a/lib/Bio/Tools/GFF.pm
+++ b/lib/Bio/Tools/GFF.pm
@@ -738,10 +738,8 @@ sub _gff1_string{
 
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
-        $name ||= 'SEQ';
-    } else {
-        $name = 'SEQ';
     }
+    $name = 'SEQ' if (! $name and $name ne "0");
 
     $str = join("\t",
                 $name,
@@ -807,7 +805,7 @@ sub _gff2_string{
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
     }
-    $name ||= 'SEQ';
+    $name = 'SEQ' if (! $name and $name ne "0");
 
     $str1 = join("\t",
                  $name,
@@ -908,10 +906,9 @@ sub _gff25_string {
 
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
-        $name ||= 'SEQ';
-    } else {
-        $name = 'SEQ';
-    }
+    } 
+    $name = 'SEQ' if (! $name and $name ne "0");
+
     $str1 = join("\t",
                  $name,
                  $feat->source_tag(),
@@ -1013,10 +1010,8 @@ sub _gff3_string {
 
     if( $feat->can('seqname') ) {
         $name = $feat->seq_id();
-        $name ||= 'SEQ';
-    } else {
-        $name = 'SEQ';
-    }
+    } 
+    $name = 'SEQ' if (! $name and $name ne "0");
 
     my @groups;
 


### PR DESCRIPTION
seq_id replaced by SEQ when the name is 0 because perl see 0 as FALSE

BUG reported here: https://github.com/NBISweden/AGAT/issues/368