### PR TITLE
Codontable bugs.

### DIFF
--- a/lib/Bio/Tools/CodonTable.pm
+++ b/lib/Bio/Tools/CodonTable.pm
@@ -330,7 +330,7 @@ sub new {
              @args);
 
     $id = 1 if ( ! defined ( $id ) );
-    $id  && $self->id($id);
+    $self->id($id);
     return $self; # success - we hope!
 }
 

--- a/lib/Bio/Tools/CodonTable.pm
+++ b/lib/Bio/Tools/CodonTable.pm
@@ -352,7 +352,7 @@ sub new {
 sub id{
     my ($self,$value) = @_;
     if( defined $value) {
-        if (  not defined $TABLES[$value] or $TABLES[$value] eq '') {
+        if (  not defined $TABLES[$value] or $TABLES[$value] eq '' or $TABLES[$value] eq "''") {
             $self->warn("Not a valid codon table ID [$value], using [1] instead ");
             $value = 1;
         }

--- a/lib/Bio/Tools/CodonTable.pm
+++ b/lib/Bio/Tools/CodonTable.pm
@@ -352,7 +352,7 @@ sub new {
 sub id{
     my ($self,$value) = @_;
     if( defined $value) {
-        if (  not defined $TABLES[$value] or $TABLES[$value] eq '' or $TABLES[$value] eq "''") {
+        if (  not defined $TABLES[$value] or $TABLES[$value] eq '' or $TABLES[$value] eq "''" or $value < 0) {
             $self->warn("Not a valid codon table ID [$value], using [1] instead ");
             $value = 1;
         }

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -18,6 +18,10 @@ my $myCodonTable = Bio::Tools::CodonTable -> new ( -id => 16);
 ok defined $myCodonTable;
 isa_ok $myCodonTable, 'Bio::Tools::CodonTable';
 
+# Access to ID table 0 
+$myCodonTable = Bio::Tools::CodonTable->new( -id => 0);
+is $myCodonTable->id(), 0;
+
 # defaults to ID 1 "Standard"
 $myCodonTable = Bio::Tools::CodonTable->new();
 is $myCodonTable->id(), 1;

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -6,7 +6,7 @@ use strict;
 BEGIN {
     use Bio::Root::Test;
 
-    test_begin(-tests => 84);
+    test_begin(-tests => 85);
 
     use_ok('Bio::Tools::CodonTable');
     use_ok('Bio::CodonUsage::IO');

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -6,7 +6,7 @@ use strict;
 BEGIN {
     use Bio::Root::Test;
 
-    test_begin(-tests => 85);
+    test_begin(-tests => 87);
 
     use_ok('Bio::Tools::CodonTable');
     use_ok('Bio::CodonUsage::IO');
@@ -21,6 +21,14 @@ isa_ok $myCodonTable, 'Bio::Tools::CodonTable';
 # Access to ID table 0 
 $myCodonTable = Bio::Tools::CodonTable->new( -id => 0);
 is $myCodonTable->id(), 0;
+
+# Access removed table e.g. 7 should return defaut table 1
+$myCodonTable = Bio::Tools::CodonTable->new( -id => 7);
+is $myCodonTable->id(), 1;
+
+# Access negative table must return defaut table 1
+$myCodonTable = Bio::Tools::CodonTable->new( -id => -2);
+is $myCodonTable->id(), 1;
 
 # defaults to ID 1 "Standard"
 $myCodonTable = Bio::Tools::CodonTable->new();


### PR DESCRIPTION
Fix bugs in codon table:

 * table 0 was not selectable via `Bio::Tools::CodonTable->new( -id => 0);`  but was working only by creating  a codon table by default and using the `id` function to set the table to 0
 * table 7-8 and 17-20 was selectable while have been removed
 * Negative value was usable value while it should not