### PR TITLE
Bug in is_ter_codon 

### DIFF
--- a/lib/Bio/Tools/CodonTable.pm
+++ b/lib/Bio/Tools/CodonTable.pm
@@ -735,10 +735,10 @@ sub is_start_codon{
 =head2 is_ter_codon
 
  Title   : is_ter_codon
- Usage   : $obj->is_ter_codon('GAA')
+ Usage   : $obj->is_ter_codon('TGA')
  Function: returns true (1) for all codons that can be used as a
            translation tarminator, false (0) for others.
- Example : $myCodonTable->is_ter_codon('ATG')
+ Example : $myCodonTable->is_ter_codon('TGA')
  Returns : boolean
  Args    : codon
 
@@ -746,30 +746,7 @@ sub is_start_codon{
 
 sub is_ter_codon{
    my ($self, $value) = @_;
-   my $id = $self->{'id'};
-
-   # We need to ensure U is mapped to T (ie. UAG)
-   $value = uc $value;
-   $value =~ tr/U/T/;
-
-   if (length $value != 3  )  {
-       # Incomplete codons are not stop codons
-       return 0;
-   } else {
-       my $result = 0;
-
-       # For all the possible codons, if any are not a stop
-       # codon, fail immediately
-       for my $c ( $self->unambiguous_codons($value) ) {
-	   my $m = substr( $TABLES[$id], $CODONS->{$c}, 1 );
-	   if($m eq $TERMINATOR) {
-	       $result = 1;
-	   } else {
-	       return 0;
-	   }
-       }
-       return $result;
-   }
+   shift->_codon_is( shift, \@STARTS, '*' );
 }
 
 # desc: compares the passed value with a single entry in the given

--- a/t/SeqTools/CodonTable.t
+++ b/t/SeqTools/CodonTable.t
@@ -6,7 +6,7 @@ use strict;
 BEGIN {
     use Bio::Root::Test;
 
-    test_begin(-tests => 84);
+    test_begin(-tests => 87);
 
     use_ok('Bio::Tools::CodonTable');
     use_ok('Bio::CodonUsage::IO');
@@ -170,9 +170,13 @@ ok $myCodonTable->is_ter_codon('TaR'), 'is_ter_codon,TaR';
 ok $myCodonTable->is_ter_codon('tRa'), 'is_ter_codon,tRa';
 is $myCodonTable->is_ter_codon('ttA'), 0, 'is_ter_codon,ttA';
 
-# Ambiguous codons should fail
-is $myCodonTable->is_ter_codon('NNN'), 0, 'is_ter_codon, ambiguous codons should fail, NNN';
-is $myCodonTable->is_ter_codon('TAN'), 0, 'is_ter_codon, ambiguous codons should fail, TAN';
+# Ambiguous codons
+is $myCodonTable->is_start_codon('NNN'), 1, 'is_start_codon, ambiguous codons should succeed, NNN';
+is $myCodonTable->is_start_codon('ATN'), 1, 'is_start_codon, ambiguous codons should succeed, ATN';
+is $myCodonTable->is_start_codon('CC'), 0, 'is_ter_codon, incomplete codons should fail, CC';
+
+is $myCodonTable->is_ter_codon('NNN'), 1, 'is_ter_codon, ambiguous codons should succeed, NNN';
+is $myCodonTable->is_ter_codon('TAN'), 1, 'is_ter_codon, ambiguous codons should succeed, TAN';
 is $myCodonTable->is_ter_codon('CC'), 0, 'is_ter_codon, incomplete codons should fail, CC';
 
 ok $myCodonTable->is_unknown_codon('jAG');


### PR DESCRIPTION
`is_ter_codon` and `is_start_codon` do not behaves the same.  ( with that PR now it does).
is_ter_codon was not verifying all unambiguous_codons, but only the first. 

I do not get why Matthew Laird that coded `is_ter_codon` in 2016 did it like that while the `_codon_is` was existing and used by `is_start_codon`  since 2010.

```
sub is_start_codon{
   shift->_codon_is( shift, \@STARTS, 'M' );
}
```

How `is_ter_codon` was coded was not behaving as explained. Indeed only the first codon for ambiguous codon was tried. It was coded Upside down (between the else and if statement).
```
       my $result = 0;

       # For all the possible codons, if any are not a stop
       # codon, fail immediately
       for my $c ( $self->unambiguous_codons($value) ) {
	   my $m = substr( $TABLES[$id], $CODONS->{$c}, 1 );
	   if($m eq $TERMINATOR) {
	       $result = 1;
	   } else {
	       return 0;
	   }
       }
       return $result;
```

Anyway using the `_codon_is ` method as  for `is_start_codon ` seems perfectly fine.