### PR TITLE
Refactor Bio::Species tests into modular files

### DIFF
--- a/t/AnnotationI.t
+++ b/t/AnnotationI.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+BEGIN {
+    use_ok('Bio::AnnotationI');
+}
+
+{
+    package MyAnnotation;
+    use base qw(Bio::AnnotationI);
+
+    sub new {
+        my $class = shift;
+        return bless {}, $class;
+    }
+
+    sub tagname  { return "mock_tag"; }
+    sub as_text  { return "Mock annotation as text"; }
+    sub hash_tree { return {}; }
+}
+
+my $a = MyAnnotation->new();
+
+isa_ok($a, 'Bio::AnnotationI');
+is($a->tagname, 'mock_tag', 'tagname returns expected value');
+is($a->as_text, 'Mock annotation as text', 'as_text returns expected value');
+

--- a/t/SeqI.t
+++ b/t/SeqI.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+BEGIN {
+    use_ok('Bio::SeqI');
+}
+
+{
+    package MySeq;
+    use base qw(Bio::SeqI);
+
+    sub new {
+        my $class = shift;
+        return bless {}, $class;
+    }
+
+    sub display_id { return "test_id"; }
+    sub seq        { return "ATGC"; }
+    sub desc       { return "Test sequence"; }
+    sub alphabet   { return "dna"; }
+}
+
+my $seq = MySeq->new();
+
+isa_ok($seq, 'Bio::SeqI');
+is($seq->display_id, 'test_id', 'display_id returns correct value');
+is($seq->seq, 'ATGC', 'seq returns correct sequence');
+

--- a/t/Species/basic.t
+++ b/t/Species/basic.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+use_ok('Bio::Species');
+
+my $sps = Bio::Species->new();
+$sps->classification(qw(sapiens Homo Hominidae Catarrhini Primates Eutheria Mammalia Vertebrata Chordata Metazoa Eukaryota));
+
+is $sps->binomial, 'Homo sapiens';
+
+$sps->sub_species('sapiensis');
+is $sps->binomial, 'Homo sapiens';
+is $sps->binomial('FULL'), 'Homo sapiens sapiensis';
+
+is $sps->sub_species, 'sapiensis';
+
+my $species = Bio::Species->new(
+    -classification => [qw(sapiens Homo Hominidae Catarrhini Primates Eutheria Mammalia Vertebrata Chordata Metazoa Eukaryota)],
+    -common_name    => 'human'
+);
+is $species->binomial, 'Homo sapiens';
+is $species->genus, 'Homo';
+


### PR DESCRIPTION
Splits `t/Species.t` into modular test files for maintainability:

- `t/Species/basic.t` – basic method and constructor tests
- `t/Species/memory.t` – memory leak and regression tests
- `t/Species/taxonomy_db.t` – Entrez Taxonomy DB fetch tests (with skip)

This supports clearer test separation and easier maintenance going forward.
