### PR TITLE
Fix warnings with Perl 5.42

### DIFF
--- a/lib/Bio/AlignIO/Handler/GenericAlignHandler.pm
+++ b/lib/Bio/AlignIO/Handler/GenericAlignHandler.pm
@@ -95,7 +95,7 @@ sub get_params {
     my $data;
     if (scalar(@ids)) {
         for my $id (@ids) {
-            if (!index($id, '-')==0) {
+            if (index($id, '-')!=0) {
                 $id = '-'.$id ;
             }
             $data->{$id} = $self->{'_params'}->{$id} if (exists $self->{'_params'}->{$id});

--- a/lib/Bio/SeqIO/Handler/GenericRichSeqHandler.pm
+++ b/lib/Bio/SeqIO/Handler/GenericRichSeqHandler.pm
@@ -376,7 +376,7 @@ sub get_params {
     my ($self, @ids) = @_;
     my %data;
     for my $id (@ids) {
-        if (!index($id, '-')==0) {
+        if (index($id, '-')!=0) {
             $id = '-'.$id ;
         }
         $data{$id} = $self->{'_params'}->{$id} if (exists $self->{'_params'}->{$id});


### PR DESCRIPTION

In Debian we are currently applying the following patch to BioPerl.
We thought you might be interested in it too.

    Description: Fix warnings with Perl 5.42
     Possible precedence problem between ! and numeric eq (==) at /build/bioperl-1.7.8/blib/lib/Bio/AlignIO/Handler/GenericAlignHandler.pm line 98.
     Possible precedence problem between ! and numeric eq (==) at /build/bioperl-1.7.8/blib/lib/Bio/SeqIO/Handler/GenericRichSeqHandler.pm line 379.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1113735
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-09-03
    

The patch is tracked in our Git repository at
https://salsa.debian.org/med-team/bioperl/raw/master/debian/patches/perl-5.42-precedence.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
