### PR TITLE
l/B/R/Test.pm: manually export Test::Most submodules.

### DIFF
--- a/lib/Bio/Root/Test.pm
+++ b/lib/Bio/Root/Test.pm
@@ -150,6 +150,12 @@ Chris Fields
 
 our @EXPORT = (
     @Test::Most::EXPORT,
+    @Test::More::EXPORT,
+    @Test::Exception::EXPORT,
+    @Test::Warn::EXPORT,
+    @Test::Deep::EXPORT,
+    @Test::Diff::EXPORT,
+    @Test::Differences::EXPORT,
 
     #@Bio::Root::Test::Warn::EXPORT,
     # Test::Warn method wrappers


### PR DESCRIPTION
Greetings,

As initially seen in [Debian bug #1136915], since inclusion of recent versions of Test::Most in Debian unstable, around April or May 2026, the Bio::Root::Test module is not reexporting submodules of Test::Most anymore.  This patch fixes, or works around, the issue by exporting the missing modules manually.

As a side note, [reexporting symbols sparked discussions on the Debian Perl mailing list], in which it was highlighted that the current approach may not be a good practice, as it makes it "harder to know where the test functions come from".  Perhaps a different approach would be in order for the future.  In the meantime, this change does the job.

In hope this helps,
Have a nice day,  :)
Étienne.

[Debian bug #1136915]: https://bugs.debian.org/1136915
[reexporting symbols sparked discussions on the Debian Perl mailing list]: https://lists.debian.org/debian-perl/2026/06/msg00006.html